### PR TITLE
Favor better/terser error handling where possible

### DIFF
--- a/bin/src/common/datastore.rs
+++ b/bin/src/common/datastore.rs
@@ -222,10 +222,7 @@ pub fn datastore() -> ProxyDatastore {
              i32",
         );
 
-        let datastore = match RocksdbDatastore::new(path, Some(max_open_files), secure_uuids) {
-            Ok(datastore) => datastore,
-            Err(err) => panic!("Could not instantiate a rocksdb datastore: {:?}", err),
-        };
+        let datastore = RocksdbDatastore::new(path, Some(max_open_files), secure_uuids).expect("Expected to be able to create the RocksDB datastore");
 
         ProxyDatastore::Rocksdb(datastore)
     } else if connection_string.starts_with("postgres://") {
@@ -238,7 +235,7 @@ pub fn datastore() -> ProxyDatastore {
         };
 
         let secret = env::var("SECRET").unwrap_or_else(|_| "".to_string());
-        let datastore = PostgresDatastore::new(pool_size, connection_string, secret, secure_uuids);
+        let datastore = PostgresDatastore::new(pool_size, connection_string, secret, secure_uuids).expect("Expected to be able to create the postgres datastore");
         ProxyDatastore::Postgres(datastore)
     } else if connection_string == "memory://" {
         let datastore = MemoryDatastore::new(true);

--- a/bin/src/server/http/rest.rs
+++ b/bin/src/server/http/rest.rs
@@ -98,32 +98,30 @@ pub fn script(req: &mut Request) -> IronResult<Response> {
 
     let path = Path::new(&statics::SCRIPT_ROOT[..]).join(name);
 
-    let contents = match File::open(&path) {
-        Ok(mut file) => {
-            let mut contents = String::new();
-
-            match file.read_to_string(&mut contents) {
-                Ok(_) => Ok(contents),
-                Err(_) => Err(create_iron_error(
-                    status::NotFound,
-                    "Could not read script".to_string(),
-                )),
-            }
-        }
-        Err(_) => Err(create_iron_error(
+    let mut file = File::open(&path).map_err(|_| {
+        create_iron_error(
             status::NotFound,
             "Could not load script".to_string(),
-        )),
-    }?;
+        )
+    })?;
 
-    match script::run(account_id, &contents, &path, payload) {
-        Ok(value) => Ok(to_response(status::Ok, &value)),
-        Err(err) => {
-            let error_message = format!("Script failed: {:?}", err);
-            Err(create_iron_error(
-                status::InternalServerError,
-                error_message,
-            ))
-        }
-    }
+    let mut contents = String::new();
+
+    file.read_to_string(&mut contents).map_err(|_| {
+        create_iron_error(
+            status::NotFound,
+            "Could not read script".to_string(),
+        )
+    })?;
+
+    let value = script::run(account_id, &contents, &path, payload).map_err(|err| {
+        let error_message = format!("Script failed: {:?}", err);
+        
+        create_iron_error(
+            status::InternalServerError,
+            error_message,
+        )
+    })?;
+
+    Ok(to_response(status::Ok, &value))
 }

--- a/bin/src/server/script/mod.rs
+++ b/bin/src/server/script/mod.rs
@@ -12,7 +12,6 @@ use std::path::Path;
 use uuid::Uuid;
 use indradb::Datastore;
 use statics;
-use std::convert::From;
 
 /// Runs a script.
 ///
@@ -55,9 +54,5 @@ pub fn run(
 
     // Run the script
     let value: Result<converters::JsonValue, LuaError> = fun.call(Value::Nil);
-
-    match value {
-        Ok(value) => Ok(value.0),
-        Err(err) => Err(errors::ScriptError::from(err))
-    }
+    Ok(value?.0)
 }

--- a/bin/src/server/script/tests.rs
+++ b/bin/src/server/script/tests.rs
@@ -2,7 +2,6 @@ use std::io::prelude::*;
 use std::fs::File;
 use regex::Regex;
 use serde_json::Value as JsonValue;
-use indradb::Datastore;
 use super::run;
 use serde_json;
 use std::path::Path;

--- a/bin/src/server/statics.rs
+++ b/bin/src/server/statics.rs
@@ -7,8 +7,7 @@ lazy_static! {
     pub static ref DATASTORE: ProxyDatastore = datastore();
 
     /// The path to the script root directory
-    pub static ref SCRIPT_ROOT: String = match env::var("INDRADB_SCRIPT_ROOT") {
-        Ok(s) => s,
-        Err(_) => Path::new(".").join("scripts").to_str().unwrap().to_string()
-    };
+    pub static ref SCRIPT_ROOT: String = env::var("INDRADB_SCRIPT_ROOT").unwrap_or_else(|_| {
+        Path::new(".").join("scripts").to_str().unwrap().to_string()
+    });
 }

--- a/bin/tests/common/datastore.rs
+++ b/bin/tests/common/datastore.rs
@@ -68,7 +68,7 @@ impl<H: HttpTransaction> Default for HttpDatastore<H> {
 impl<H: HttpTransaction> Drop for HttpDatastore<H> {
     fn drop(&mut self) {
         if let Err(err) = self.server.kill() {
-            panic!(format!("Could not drop server instance: {}", err))
+            panic!(format!("Could not kill server instance: {}", err))
         }
     }
 }

--- a/lib/benches/pg.rs
+++ b/lib/benches/pg.rs
@@ -23,7 +23,7 @@ fn datastore() -> PostgresDatastore {
     });
 
     let secret = "OME88YorohonzPNWEFsi0dIsouXWqeO$".to_string();
-    PostgresDatastore::new(Some(1), connection_string, secret, false)
+    PostgresDatastore::new(Some(1), connection_string, secret, false).unwrap()
 }
 
 bench_transaction_impl!(datastore());

--- a/lib/src/pg/datastore.rs
+++ b/lib/src/pg/datastore.rs
@@ -47,7 +47,7 @@ impl PostgresDatastore {
         connection_string: String,
         secret: String,
         secure_uuids: bool,
-    ) -> PostgresDatastore {
+    ) -> Result<PostgresDatastore, Error> {
         let unwrapped_pool_size: u32 = match pool_size {
             Some(val) => val,
             None => {
@@ -60,21 +60,14 @@ impl PostgresDatastore {
             }
         };
 
-        let manager = match PostgresConnectionManager::new(&*connection_string, TlsMode::None) {
-            Ok(manager) => manager,
-            Err(err) => panic!("Could not connect to the postgres database: {}", err),
-        };
+        let manager = PostgresConnectionManager::new(&*connection_string, TlsMode::None)?;
+        let pool = Pool::builder().max_size(unwrapped_pool_size).build(manager)?;
 
-        let pool = Pool::builder()
-            .max_size(unwrapped_pool_size)
-            .build(manager)
-            .expect("Expected to be able to build a new database pool");
-
-        PostgresDatastore {
+        Ok(PostgresDatastore {
             pool: pool,
             secret: secret,
             secure_uuids: secure_uuids,
-        }
+        })
     }
 
     /// Creates a new postgres-backed datastore.
@@ -82,13 +75,10 @@ impl PostgresDatastore {
     /// # Arguments
     /// * `connetion_string` - The postgres database connection string.
     pub fn create_schema(connection_string: String) -> Result<(), Error> {
-        let conn = match postgres::Connection::connect(connection_string, postgres::TlsMode::None) {
-            Ok(conn) => conn,
-            Err(err) => {
-                let message = format!("Could not connect to the postgres database: {}", err);
-                return Err(Error::Unexpected(message));
-            }
-        };
+        let conn = postgres::Connection::connect(connection_string, postgres::TlsMode::None).map_err(|err| {
+            let message = format!("Could not connect to the postgres database: {}", err);
+            Error::Unexpected(message)
+        })?;
 
         for statement in schema::SCHEMA.split(";") {
             conn.execute(statement, &vec![])?;
@@ -184,15 +174,9 @@ impl PostgresTransaction {
         let conn = Box::new(conn);
 
         let trans = unsafe {
-            mem::transmute(match conn.transaction() {
-                Ok(trans) => trans,
-                Err(err) => {
-                    return Err(Error::Unexpected(format!(
-                        "Could not create transaction: {}",
-                        err
-                    )))
-                }
-            })
+            mem::transmute(conn.transaction().map_err(|err| {
+                Error::Unexpected(format!("Could not create transaction: {}", err))
+            })?)
         };
 
         Ok(PostgresTransaction {
@@ -516,7 +500,7 @@ impl Transaction for PostgresTransaction {
             return Ok(count as u64);
         }
 
-        panic!("Unreachable point hit");
+        unreachable!();
     }
 
     fn get_global_metadata(&self, name: String) -> Result<JsonValue, Error> {

--- a/lib/src/pg/tests.rs
+++ b/lib/src/pg/tests.rs
@@ -15,5 +15,5 @@ full_test_impl!({
     });
 
     let secret = "OME88YorohonzPNWEFsi0dIsouXWqeO$".to_string();
-    PostgresDatastore::new(Some(1), connection_string, secret, false)
+    PostgresDatastore::new(Some(1), connection_string, secret, false).unwrap()
 });

--- a/lib/src/rdb/datastore.rs
+++ b/lib/src/rdb/datastore.rs
@@ -402,7 +402,7 @@ impl RocksdbTransaction {
         let mapped = filtered.map(|item| match item {
             Ok(Some(value)) => Ok(value),
             Err(err) => Err(err),
-            _ => panic!("Unexpected item: {:?}", item),
+            _ => unreachable!(),
         });
 
         Box::new(mapped)


### PR DESCRIPTION
Most notably, this PR changes the PG datastore to not panic on initialization, in favor of propagating errors instead.

Where possible, current error handling is switched to something more terse where possible. Usually this involves the use of `map_err`.