### PR TITLE
Change transaction trait to use references

### DIFF
--- a/bin/src/common/datastore.rs
+++ b/bin/src/common/datastore.rs
@@ -98,7 +98,7 @@ impl Transaction for ProxyTransaction {
         proxy_transaction!(self, get_global_metadata, key)
     }
 
-    fn set_global_metadata(&self, key: &str, value: JsonValue) -> Result<(), Error> {
+    fn set_global_metadata(&self, key: &str, value: &JsonValue) -> Result<(), Error> {
         proxy_transaction!(self, set_global_metadata, key, value)
     }
 
@@ -118,7 +118,7 @@ impl Transaction for ProxyTransaction {
         &self,
         q: &VertexQuery,
         key: &str,
-        value: JsonValue,
+        value: &JsonValue,
     ) -> Result<(), Error> {
         proxy_transaction!(self, set_vertex_metadata, q, key, value)
     }
@@ -131,7 +131,7 @@ impl Transaction for ProxyTransaction {
         proxy_transaction!(self, get_edge_metadata, q, key)
     }
 
-    fn set_edge_metadata(&self, q: &EdgeQuery, key: &str, value: JsonValue) -> Result<(), Error> {
+    fn set_edge_metadata(&self, q: &EdgeQuery, key: &str, value: &JsonValue) -> Result<(), Error> {
         proxy_transaction!(self, set_edge_metadata, q, key, value)
     }
 

--- a/bin/src/common/datastore.rs
+++ b/bin/src/common/datastore.rs
@@ -57,15 +57,15 @@ pub enum ProxyTransaction {
 }
 
 impl Transaction for ProxyTransaction {
-    fn get_vertices(&self, q: VertexQuery) -> Result<Vec<Vertex>, Error> {
+    fn get_vertices(&self, q: &VertexQuery) -> Result<Vec<Vertex>, Error> {
         proxy_transaction!(self, get_vertices, q)
     }
 
-    fn create_vertex(&self, t: Type) -> Result<Uuid, Error> {
+    fn create_vertex(&self, t: &Type) -> Result<Uuid, Error> {
         proxy_transaction!(self, create_vertex, t)
     }
 
-    fn delete_vertices(&self, q: VertexQuery) -> Result<(), Error> {
+    fn delete_vertices(&self, q: &VertexQuery) -> Result<(), Error> {
         proxy_transaction!(self, delete_vertices, q)
     }
 
@@ -73,69 +73,69 @@ impl Transaction for ProxyTransaction {
         proxy_transaction!(self, get_vertex_count,)
     }
 
-    fn create_edge(&self, key: EdgeKey) -> Result<bool, Error> {
+    fn create_edge(&self, key: &EdgeKey) -> Result<bool, Error> {
         proxy_transaction!(self, create_edge, key)
     }
 
-    fn get_edges(&self, q: EdgeQuery) -> Result<Vec<Edge>, Error> {
+    fn get_edges(&self, q: &EdgeQuery) -> Result<Vec<Edge>, Error> {
         proxy_transaction!(self, get_edges, q)
     }
 
-    fn delete_edges(&self, q: EdgeQuery) -> Result<(), Error> {
+    fn delete_edges(&self, q: &EdgeQuery) -> Result<(), Error> {
         proxy_transaction!(self, delete_edges, q)
     }
 
     fn get_edge_count(
         &self,
         id: Uuid,
-        type_filter: Option<Type>,
+        type_filter: Option<&Type>,
         direction: EdgeDirection,
     ) -> Result<u64, Error> {
         proxy_transaction!(self, get_edge_count, id, type_filter, direction)
     }
 
-    fn get_global_metadata(&self, key: String) -> Result<Option<JsonValue>, Error> {
+    fn get_global_metadata(&self, key: &str) -> Result<Option<JsonValue>, Error> {
         proxy_transaction!(self, get_global_metadata, key)
     }
 
-    fn set_global_metadata(&self, key: String, value: JsonValue) -> Result<(), Error> {
+    fn set_global_metadata(&self, key: &str, value: JsonValue) -> Result<(), Error> {
         proxy_transaction!(self, set_global_metadata, key, value)
     }
 
-    fn delete_global_metadata(&self, key: String) -> Result<(), Error> {
+    fn delete_global_metadata(&self, key: &str) -> Result<(), Error> {
         proxy_transaction!(self, delete_global_metadata, key)
     }
 
     fn get_vertex_metadata(
         &self,
-        q: VertexQuery,
-        key: String,
+        q: &VertexQuery,
+        key: &str,
     ) -> Result<Vec<VertexMetadata>, Error> {
         proxy_transaction!(self, get_vertex_metadata, q, key)
     }
 
     fn set_vertex_metadata(
         &self,
-        q: VertexQuery,
-        key: String,
+        q: &VertexQuery,
+        key: &str,
         value: JsonValue,
     ) -> Result<(), Error> {
         proxy_transaction!(self, set_vertex_metadata, q, key, value)
     }
 
-    fn delete_vertex_metadata(&self, q: VertexQuery, key: String) -> Result<(), Error> {
+    fn delete_vertex_metadata(&self, q: &VertexQuery, key: &str) -> Result<(), Error> {
         proxy_transaction!(self, delete_vertex_metadata, q, key)
     }
 
-    fn get_edge_metadata(&self, q: EdgeQuery, key: String) -> Result<Vec<EdgeMetadata>, Error> {
+    fn get_edge_metadata(&self, q: &EdgeQuery, key: &str) -> Result<Vec<EdgeMetadata>, Error> {
         proxy_transaction!(self, get_edge_metadata, q, key)
     }
 
-    fn set_edge_metadata(&self, q: EdgeQuery, key: String, value: JsonValue) -> Result<(), Error> {
+    fn set_edge_metadata(&self, q: &EdgeQuery, key: &str, value: JsonValue) -> Result<(), Error> {
         proxy_transaction!(self, set_edge_metadata, q, key, value)
     }
 
-    fn delete_edge_metadata(&self, q: EdgeQuery, key: String) -> Result<(), Error> {
+    fn delete_edge_metadata(&self, q: &EdgeQuery, key: &str) -> Result<(), Error> {
         proxy_transaction!(self, delete_edge_metadata, q, key)
     }
 }

--- a/bin/src/server/http/endpoints.rs
+++ b/bin/src/server/http/endpoints.rs
@@ -195,7 +195,7 @@ fn set_global_metadata(
 ) -> Result<JsonValue, IronError> {
     let name = get_json_obj_value::<String>(item, "name")?;
     let value = get_json_obj_value::<JsonValue>(item, "value")?;
-    execute_item(trans.set_global_metadata(&name, value))
+    execute_item(trans.set_global_metadata(&name, &value))
 }
 
 fn delete_global_metadata(
@@ -222,7 +222,7 @@ fn set_vertex_metadata(
     let q = get_json_obj_value::<VertexQuery>(item, "query")?;
     let name = get_json_obj_value::<String>(item, "name")?;
     let value = get_json_obj_value::<JsonValue>(item, "value")?;
-    execute_item(trans.set_vertex_metadata(&q, &name, value))
+    execute_item(trans.set_vertex_metadata(&q, &name, &value))
 }
 
 fn delete_vertex_metadata(
@@ -250,7 +250,7 @@ fn set_edge_metadata(
     let q = get_json_obj_value::<EdgeQuery>(item, "query")?;
     let name = get_json_obj_value::<String>(item, "name")?;
     let value = get_json_obj_value::<JsonValue>(item, "value")?;
-    execute_item(trans.set_edge_metadata(&q, &name, value))
+    execute_item(trans.set_edge_metadata(&q, &name, &value))
 }
 
 fn delete_edge_metadata(

--- a/bin/src/server/http/endpoints.rs
+++ b/bin/src/server/http/endpoints.rs
@@ -121,7 +121,7 @@ fn create_vertex(
     item: &serde_json::Map<String, JsonValue>,
 ) -> Result<JsonValue, IronError> {
     let t = get_json_obj_value::<Type>(item, "type")?;
-    execute_item(trans.create_vertex(t))
+    execute_item(trans.create_vertex(&t))
 }
 
 fn get_vertices(
@@ -129,7 +129,7 @@ fn get_vertices(
     item: &serde_json::Map<String, JsonValue>,
 ) -> Result<JsonValue, IronError> {
     let q = get_json_obj_value::<VertexQuery>(item, "query")?;
-    execute_item(trans.get_vertices(q))
+    execute_item(trans.get_vertices(&q))
 }
 
 fn delete_vertices(
@@ -137,7 +137,7 @@ fn delete_vertices(
     item: &serde_json::Map<String, JsonValue>,
 ) -> Result<JsonValue, IronError> {
     let q = get_json_obj_value::<VertexQuery>(item, "query")?;
-    execute_item(trans.delete_vertices(q))
+    execute_item(trans.delete_vertices(&q))
 }
 
 fn get_vertex_count(
@@ -152,7 +152,7 @@ fn create_edge(
     item: &serde_json::Map<String, JsonValue>,
 ) -> Result<JsonValue, IronError> {
     let key = get_json_obj_value::<EdgeKey>(item, "key")?;
-    execute_item(trans.create_edge(key))
+    execute_item(trans.create_edge(&key))
 }
 
 fn get_edges(
@@ -160,7 +160,7 @@ fn get_edges(
     item: &serde_json::Map<String, JsonValue>,
 ) -> Result<JsonValue, IronError> {
     let q = get_json_obj_value::<EdgeQuery>(item, "query")?;
-    execute_item(trans.get_edges(q))
+    execute_item(trans.get_edges(&q))
 }
 
 fn delete_edges(
@@ -168,7 +168,7 @@ fn delete_edges(
     item: &serde_json::Map<String, JsonValue>,
 ) -> Result<JsonValue, IronError> {
     let q = get_json_obj_value::<EdgeQuery>(item, "query")?;
-    execute_item(trans.delete_edges(q))
+    execute_item(trans.delete_edges(&q))
 }
 
 fn get_edge_count(
@@ -178,7 +178,7 @@ fn get_edge_count(
     let id = get_json_obj_value::<Uuid>(item, "id")?;
     let type_filter = get_json_obj_value::<Option<Type>>(item, "type_filter")?;
     let direction = get_json_obj_value::<EdgeDirection>(item, "direction")?;
-    execute_item(trans.get_edge_count(id, type_filter, direction))
+    execute_item(trans.get_edge_count(id, type_filter.as_ref(), direction))
 }
 
 fn get_global_metadata(
@@ -186,7 +186,7 @@ fn get_global_metadata(
     item: &serde_json::Map<String, JsonValue>,
 ) -> Result<JsonValue, IronError> {
     let name = get_json_obj_value::<String>(item, "name")?;
-    execute_item(trans.get_global_metadata(name))
+    execute_item(trans.get_global_metadata(&name))
 }
 
 fn set_global_metadata(
@@ -195,7 +195,7 @@ fn set_global_metadata(
 ) -> Result<JsonValue, IronError> {
     let name = get_json_obj_value::<String>(item, "name")?;
     let value = get_json_obj_value::<JsonValue>(item, "value")?;
-    execute_item(trans.set_global_metadata(name, value))
+    execute_item(trans.set_global_metadata(&name, value))
 }
 
 fn delete_global_metadata(
@@ -203,7 +203,7 @@ fn delete_global_metadata(
     item: &serde_json::Map<String, JsonValue>,
 ) -> Result<JsonValue, IronError> {
     let name = get_json_obj_value::<String>(item, "name")?;
-    execute_item(trans.delete_global_metadata(name))
+    execute_item(trans.delete_global_metadata(&name))
 }
 
 fn get_vertex_metadata(
@@ -212,7 +212,7 @@ fn get_vertex_metadata(
 ) -> Result<JsonValue, IronError> {
     let q = get_json_obj_value::<VertexQuery>(item, "query")?;
     let name = get_json_obj_value::<String>(item, "name")?;
-    execute_item(trans.get_vertex_metadata(q, name))
+    execute_item(trans.get_vertex_metadata(&q, &name))
 }
 
 fn set_vertex_metadata(
@@ -222,7 +222,7 @@ fn set_vertex_metadata(
     let q = get_json_obj_value::<VertexQuery>(item, "query")?;
     let name = get_json_obj_value::<String>(item, "name")?;
     let value = get_json_obj_value::<JsonValue>(item, "value")?;
-    execute_item(trans.set_vertex_metadata(q, name, value))
+    execute_item(trans.set_vertex_metadata(&q, &name, value))
 }
 
 fn delete_vertex_metadata(
@@ -231,7 +231,7 @@ fn delete_vertex_metadata(
 ) -> Result<JsonValue, IronError> {
     let q = get_json_obj_value::<VertexQuery>(item, "query")?;
     let name = get_json_obj_value::<String>(item, "name")?;
-    execute_item(trans.delete_vertex_metadata(q, name))
+    execute_item(trans.delete_vertex_metadata(&q, &name))
 }
 
 fn get_edge_metadata(
@@ -240,7 +240,7 @@ fn get_edge_metadata(
 ) -> Result<JsonValue, IronError> {
     let q = get_json_obj_value::<EdgeQuery>(item, "query")?;
     let name = get_json_obj_value::<String>(item, "name")?;
-    execute_item(trans.get_edge_metadata(q, name))
+    execute_item(trans.get_edge_metadata(&q, &name))
 }
 
 fn set_edge_metadata(
@@ -250,7 +250,7 @@ fn set_edge_metadata(
     let q = get_json_obj_value::<EdgeQuery>(item, "query")?;
     let name = get_json_obj_value::<String>(item, "name")?;
     let value = get_json_obj_value::<JsonValue>(item, "value")?;
-    execute_item(trans.set_edge_metadata(q, name, value))
+    execute_item(trans.set_edge_metadata(&q, &name, value))
 }
 
 fn delete_edge_metadata(
@@ -259,7 +259,7 @@ fn delete_edge_metadata(
 ) -> Result<JsonValue, IronError> {
     let q = get_json_obj_value::<EdgeQuery>(item, "query")?;
     let name = get_json_obj_value::<String>(item, "name")?;
-    execute_item(trans.delete_edge_metadata(q, name))
+    execute_item(trans.delete_edge_metadata(&q, &name))
 }
 
 fn execute_item<T: Serialize>(result: Result<T, Error>) -> Result<JsonValue, IronError> {

--- a/bin/src/server/script/api.rs
+++ b/bin/src/server/script/api.rs
@@ -10,7 +10,7 @@ pub fn create_vertex(
     trans: &ProxyTransaction,
     t: converters::Type,
 ) -> Result<converters::Uuid, Error> {
-    Ok(converters::Uuid::new(trans.create_vertex(t.0)?))
+    Ok(converters::Uuid::new(trans.create_vertex(&t.0)?))
 }
 
 pub fn get_vertices(
@@ -18,14 +18,14 @@ pub fn get_vertices(
     q: converters::VertexQuery,
 ) -> Result<Vec<converters::Vertex>, Error> {
     Ok(trans
-        .get_vertices(q.0)?
+        .get_vertices(&q.0)?
         .into_iter()
         .map(converters::Vertex::new)
         .collect())
 }
 
 pub fn delete_vertices(trans: &ProxyTransaction, q: converters::VertexQuery) -> Result<(), Error> {
-    trans.delete_vertices(q.0)
+    trans.delete_vertices(&q.0)
 }
 
 pub fn get_vertex_count(trans: &ProxyTransaction, _: ()) -> Result<u64, Error> {
@@ -33,7 +33,7 @@ pub fn get_vertex_count(trans: &ProxyTransaction, _: ()) -> Result<u64, Error> {
 }
 
 pub fn create_edge(trans: &ProxyTransaction, key: converters::EdgeKey) -> Result<(), Error> {
-    trans.create_edge(key.0)?;
+    trans.create_edge(&key.0)?;
     Ok(())
 }
 
@@ -42,14 +42,14 @@ pub fn get_edges(
     q: converters::EdgeQuery,
 ) -> Result<Vec<converters::Edge>, Error> {
     Ok(trans
-        .get_edges(q.0)?
+        .get_edges(&q.0)?
         .into_iter()
         .map(converters::Edge::new)
         .collect())
 }
 
 pub fn delete_edges(trans: &ProxyTransaction, q: converters::EdgeQuery) -> Result<(), Error> {
-    trans.delete_edges(q.0)?;
+    trans.delete_edges(&q.0)?;
     Ok(())
 }
 
@@ -61,7 +61,7 @@ pub fn get_edge_count(
         converters::EdgeDirection,
     ),
 ) -> Result<u64, Error> {
-    Ok(trans.get_edge_count(id.0, type_filter.map(|t| t.0), direction.0)?)
+    Ok(trans.get_edge_count(id.0, type_filter.as_ref().map(|t| &t.0), direction.0)?)
 }
 
 pub fn get_global_metadata(
@@ -70,7 +70,7 @@ pub fn get_global_metadata(
 ) -> Result<converters::JsonValue, Error> {
     Ok(converters::JsonValue::new(
         trans
-            .get_global_metadata(key)?
+            .get_global_metadata(&key)?
             .unwrap_or_else(|| JsonValue::Null),
     ))
 }
@@ -79,12 +79,12 @@ pub fn set_global_metadata(
     trans: &ProxyTransaction,
     (key, value): (String, converters::JsonValue),
 ) -> Result<(), Error> {
-    trans.set_global_metadata(key, value.0)?;
+    trans.set_global_metadata(&key, value.0)?;
     Ok(())
 }
 
 pub fn delete_global_metadata(trans: &ProxyTransaction, key: String) -> Result<(), Error> {
-    trans.delete_global_metadata(key)?;
+    trans.delete_global_metadata(&key)?;
     Ok(())
 }
 
@@ -93,7 +93,7 @@ pub fn get_vertex_metadata(
     (q, key): (converters::VertexQuery, String),
 ) -> Result<Vec<converters::VertexMetadata>, Error> {
     Ok(trans
-        .get_vertex_metadata(q.0, key)?
+        .get_vertex_metadata(&q.0, &key)?
         .into_iter()
         .map(converters::VertexMetadata::new)
         .collect())
@@ -103,14 +103,14 @@ pub fn set_vertex_metadata(
     trans: &ProxyTransaction,
     (q, key, value): (converters::VertexQuery, String, converters::JsonValue),
 ) -> Result<(), Error> {
-    Ok(trans.set_vertex_metadata(q.0, key, value.0)?)
+    Ok(trans.set_vertex_metadata(&q.0, &key, value.0)?)
 }
 
 pub fn delete_vertex_metadata(
     trans: &ProxyTransaction,
     (q, key): (converters::VertexQuery, String),
 ) -> Result<(), Error> {
-    trans.delete_vertex_metadata(q.0, key)?;
+    trans.delete_vertex_metadata(&q.0, &key)?;
     Ok(())
 }
 
@@ -119,7 +119,7 @@ pub fn get_edge_metadata(
     (q, key): (converters::EdgeQuery, String),
 ) -> Result<Vec<converters::EdgeMetadata>, Error> {
     Ok(trans
-        .get_edge_metadata(q.0, key)?
+        .get_edge_metadata(&q.0, &key)?
         .into_iter()
         .map(converters::EdgeMetadata::new)
         .collect())
@@ -129,7 +129,7 @@ pub fn set_edge_metadata(
     trans: &ProxyTransaction,
     (q, key, value): (converters::EdgeQuery, String, converters::JsonValue),
 ) -> Result<(), Error> {
-    trans.set_edge_metadata(q.0, key, value.0)?;
+    trans.set_edge_metadata(&q.0, &key, value.0)?;
     Ok(())
 }
 
@@ -137,6 +137,6 @@ pub fn delete_edge_metadata(
     trans: &ProxyTransaction,
     (q, key): (converters::EdgeQuery, String),
 ) -> Result<(), Error> {
-    trans.delete_edge_metadata(q.0, key)?;
+    trans.delete_edge_metadata(&q.0, &key)?;
     Ok(())
 }

--- a/bin/src/server/script/api.rs
+++ b/bin/src/server/script/api.rs
@@ -79,7 +79,7 @@ pub fn set_global_metadata(
     trans: &ProxyTransaction,
     (key, value): (String, converters::JsonValue),
 ) -> Result<(), Error> {
-    trans.set_global_metadata(&key, value.0)?;
+    trans.set_global_metadata(&key, &value.0)?;
     Ok(())
 }
 
@@ -103,7 +103,7 @@ pub fn set_vertex_metadata(
     trans: &ProxyTransaction,
     (q, key, value): (converters::VertexQuery, String, converters::JsonValue),
 ) -> Result<(), Error> {
-    Ok(trans.set_vertex_metadata(&q.0, &key, value.0)?)
+    Ok(trans.set_vertex_metadata(&q.0, &key, &value.0)?)
 }
 
 pub fn delete_vertex_metadata(
@@ -129,7 +129,7 @@ pub fn set_edge_metadata(
     trans: &ProxyTransaction,
     (q, key, value): (converters::EdgeQuery, String, converters::JsonValue),
 ) -> Result<(), Error> {
-    trans.set_edge_metadata(&q.0, &key, value.0)?;
+    trans.set_edge_metadata(&q.0, &key, &value.0)?;
     Ok(())
 }
 

--- a/bin/src/server/script/mapreduce/mod.rs
+++ b/bin/src/server/script/mapreduce/mod.rs
@@ -52,7 +52,7 @@ pub fn execute_mapreduce(contents: String, path: String, arg: JsonValue, sender:
             Ok(trans) => trans,
             Err(err) => {
                 let message = format!("Query setup failed: {:?}", err);
-            sender.0.send(Update::Err(json!(message))).ok();
+                sender.0.send(Update::Err(json!(message))).ok();
                 return;
             }
         };

--- a/bin/src/server/script/mapreduce/mod.rs
+++ b/bin/src/server/script/mapreduce/mod.rs
@@ -52,7 +52,7 @@ pub fn execute_mapreduce(contents: String, path: String, arg: JsonValue, sender:
             Ok(trans) => trans,
             Err(err) => {
                 let message = format!("Query setup failed: {:?}", err);
-                sender.0.send(Update::Err(json!(message))).ok();
+            sender.0.send(Update::Err(json!(message))).ok();
                 return;
             }
         };
@@ -66,7 +66,7 @@ pub fn execute_mapreduce(contents: String, path: String, arg: JsonValue, sender:
                 limit: *statics::MAP_REDUCE_QUERY_LIMIT,
             };
 
-            let vertices = match trans.get_vertices(q) {
+            let vertices = match trans.get_vertices(&q) {
                 Ok(vertices) => vertices,
                 Err(err) => {
                     let message = format!("Query failed: {:?}", err);
@@ -128,7 +128,7 @@ mod tests {
     fn add_seed() {
         let trans = statics::DATASTORE.transaction().unwrap();
         trans
-            .create_vertex(Type::new("foo".to_string()).unwrap())
+            .create_vertex(&Type::new("foo".to_string()).unwrap())
             .unwrap();
     }
 

--- a/bin/tests/batch.rs
+++ b/bin/tests/batch.rs
@@ -206,7 +206,7 @@ impl Transaction for BatchTransaction {
         }))
     }
 
-    fn set_global_metadata(&self, name: &str, value: JsonValue) -> Result<(), Error> {
+    fn set_global_metadata(&self, name: &str, value: &JsonValue) -> Result<(), Error> {
         self.request(&json!({
             "action": "set_global_metadata",
             "name": name,
@@ -237,7 +237,7 @@ impl Transaction for BatchTransaction {
         &self,
         q: &VertexQuery,
         name: &str,
-        value: JsonValue,
+        value: &JsonValue,
     ) -> Result<(), Error> {
         self.request(&json!({
             "action": "set_vertex_metadata",
@@ -263,7 +263,7 @@ impl Transaction for BatchTransaction {
         }))
     }
 
-    fn set_edge_metadata(&self, q: &EdgeQuery, name: &str, value: JsonValue) -> Result<(), Error> {
+    fn set_edge_metadata(&self, q: &EdgeQuery, name: &str, value: &JsonValue) -> Result<(), Error> {
         self.request(&json!({
             "action": "set_edge_metadata",
             "query": q,

--- a/bin/tests/batch.rs
+++ b/bin/tests/batch.rs
@@ -137,21 +137,21 @@ impl BatchTransaction {
 }
 
 impl Transaction for BatchTransaction {
-    fn create_vertex(&self, t: Type) -> Result<Uuid, Error> {
+    fn create_vertex(&self, t: &Type) -> Result<Uuid, Error> {
         self.request(&json!({
             "action": "create_vertex",
             "type": t.0
         }))
     }
 
-    fn get_vertices(&self, q: VertexQuery) -> Result<Vec<Vertex>, Error> {
+    fn get_vertices(&self, q: &VertexQuery) -> Result<Vec<Vertex>, Error> {
         self.request(&json!({
             "action": "get_vertices",
             "query": q
         }))
     }
 
-    fn delete_vertices(&self, q: VertexQuery) -> Result<(), Error> {
+    fn delete_vertices(&self, q: &VertexQuery) -> Result<(), Error> {
         self.request(&json!({
             "action": "delete_vertices",
             "query": q
@@ -164,21 +164,21 @@ impl Transaction for BatchTransaction {
         }))
     }
 
-    fn create_edge(&self, e: EdgeKey) -> Result<bool, Error> {
+    fn create_edge(&self, e: &EdgeKey) -> Result<bool, Error> {
         self.request(&json!({
             "action": "create_edge",
             "key": e,
         }))
     }
 
-    fn get_edges(&self, q: EdgeQuery) -> Result<Vec<Edge>, Error> {
+    fn get_edges(&self, q: &EdgeQuery) -> Result<Vec<Edge>, Error> {
         self.request(&json!({
             "action": "get_edges",
             "query": q
         }))
     }
 
-    fn delete_edges(&self, q: EdgeQuery) -> Result<(), Error> {
+    fn delete_edges(&self, q: &EdgeQuery) -> Result<(), Error> {
         self.request(&json!({
             "action": "delete_edges",
             "query": q
@@ -188,7 +188,7 @@ impl Transaction for BatchTransaction {
     fn get_edge_count(
         &self,
         id: Uuid,
-        type_filter: Option<Type>,
+        type_filter: Option<&Type>,
         direction: EdgeDirection,
     ) -> Result<u64, Error> {
         self.request(&json!({
@@ -199,14 +199,14 @@ impl Transaction for BatchTransaction {
         }))
     }
 
-    fn get_global_metadata(&self, name: String) -> Result<Option<JsonValue>, Error> {
+    fn get_global_metadata(&self, name: &str) -> Result<Option<JsonValue>, Error> {
         self.request(&json!({
             "action": "get_global_metadata",
             "name": name
         }))
     }
 
-    fn set_global_metadata(&self, name: String, value: JsonValue) -> Result<(), Error> {
+    fn set_global_metadata(&self, name: &str, value: JsonValue) -> Result<(), Error> {
         self.request(&json!({
             "action": "set_global_metadata",
             "name": name,
@@ -214,7 +214,7 @@ impl Transaction for BatchTransaction {
         }))
     }
 
-    fn delete_global_metadata(&self, name: String) -> Result<(), Error> {
+    fn delete_global_metadata(&self, name: &str) -> Result<(), Error> {
         self.request(&json!({
             "action": "delete_global_metadata",
             "name": name
@@ -223,8 +223,8 @@ impl Transaction for BatchTransaction {
 
     fn get_vertex_metadata(
         &self,
-        q: VertexQuery,
-        name: String,
+        q: &VertexQuery,
+        name: &str,
     ) -> Result<Vec<VertexMetadata>, Error> {
         self.request(&json!({
             "action": "get_vertex_metadata",
@@ -235,8 +235,8 @@ impl Transaction for BatchTransaction {
 
     fn set_vertex_metadata(
         &self,
-        q: VertexQuery,
-        name: String,
+        q: &VertexQuery,
+        name: &str,
         value: JsonValue,
     ) -> Result<(), Error> {
         self.request(&json!({
@@ -247,7 +247,7 @@ impl Transaction for BatchTransaction {
         }))
     }
 
-    fn delete_vertex_metadata(&self, q: VertexQuery, name: String) -> Result<(), Error> {
+    fn delete_vertex_metadata(&self, q: &VertexQuery, name: &str) -> Result<(), Error> {
         self.request(&json!({
             "action": "delete_vertex_metadata",
             "query": q,
@@ -255,7 +255,7 @@ impl Transaction for BatchTransaction {
         }))
     }
 
-    fn get_edge_metadata(&self, q: EdgeQuery, name: String) -> Result<Vec<EdgeMetadata>, Error> {
+    fn get_edge_metadata(&self, q: &EdgeQuery, name: &str) -> Result<Vec<EdgeMetadata>, Error> {
         self.request(&json!({
             "action": "get_edge_metadata",
             "query": q,
@@ -263,7 +263,7 @@ impl Transaction for BatchTransaction {
         }))
     }
 
-    fn set_edge_metadata(&self, q: EdgeQuery, name: String, value: JsonValue) -> Result<(), Error> {
+    fn set_edge_metadata(&self, q: &EdgeQuery, name: &str, value: JsonValue) -> Result<(), Error> {
         self.request(&json!({
             "action": "set_edge_metadata",
             "query": q,
@@ -272,7 +272,7 @@ impl Transaction for BatchTransaction {
         }))
     }
 
-    fn delete_edge_metadata(&self, q: EdgeQuery, name: String) -> Result<(), Error> {
+    fn delete_edge_metadata(&self, q: &EdgeQuery, name: &str) -> Result<(), Error> {
         self.request(&json!({
             "action": "delete_edge_metadata",
             "query": q,

--- a/lib/benches/common/benches.rs
+++ b/lib/benches/common/benches.rs
@@ -9,7 +9,7 @@ where
     b.iter(|| {
         let trans = datastore.transaction().unwrap();
         let t = Type::new("user".to_string()).unwrap();
-        trans.create_vertex(t).unwrap();
+        trans.create_vertex(&t).unwrap();
     });
 }
 
@@ -21,13 +21,13 @@ where
     let id = {
         let trans = datastore.transaction().unwrap();
         let t = Type::new("test_name".to_string()).unwrap();
-        trans.create_vertex(t).unwrap()
+        trans.create_vertex(&t).unwrap()
     };
 
     b.iter(|| {
         let trans = datastore.transaction().unwrap();
         let q = VertexQuery::Vertices { ids: vec![id] };
-        trans.get_vertices(q).unwrap();
+        trans.get_vertices(&q).unwrap();
     });
 }
 
@@ -39,8 +39,8 @@ where
     let (outbound_id, inbound_id) = {
         let trans = datastore.transaction().unwrap();
         let vertex_t = Type::new("test_vertex_type".to_string()).unwrap();
-        let outbound_id = trans.create_vertex(vertex_t.clone()).unwrap();
-        let inbound_id = trans.create_vertex(vertex_t).unwrap();
+        let outbound_id = trans.create_vertex(&vertex_t).unwrap();
+        let inbound_id = trans.create_vertex(&vertex_t).unwrap();
         (outbound_id, inbound_id)
     };
 
@@ -48,7 +48,7 @@ where
         let trans = datastore.transaction().unwrap();
         let edge_t = Type::new("test_vertex_type".to_string()).unwrap();
         let k = EdgeKey::new(outbound_id, edge_t, inbound_id);
-        trans.create_edge(k).unwrap();
+        trans.create_edge(&k).unwrap();
     });
 }
 
@@ -61,10 +61,10 @@ where
         let trans = datastore.transaction().unwrap();
         let vertex_t = Type::new("test_vertex_type".to_string()).unwrap();
         let edge_t = Type::new("test_vertex_type".to_string()).unwrap();
-        let outbound_id = trans.create_vertex(vertex_t.clone()).unwrap();
-        let inbound_id = trans.create_vertex(vertex_t).unwrap();
+        let outbound_id = trans.create_vertex(&vertex_t).unwrap();
+        let inbound_id = trans.create_vertex(&vertex_t).unwrap();
         let key = EdgeKey::new(outbound_id, edge_t, inbound_id);
-        trans.create_edge(key).unwrap();
+        trans.create_edge(&key).unwrap();
         (outbound_id, inbound_id)
     };
 
@@ -74,7 +74,7 @@ where
         let q = EdgeQuery::Edges {
             keys: vec![EdgeKey::new(outbound_id, edge_t, inbound_id)],
         };
-        trans.get_edges(q).unwrap();
+        trans.get_edges(&q).unwrap();
     });
 }
 
@@ -87,10 +87,10 @@ where
         let trans = datastore.transaction().unwrap();
         let vertex_t = Type::new("test_vertex_type".to_string()).unwrap();
         let edge_t = Type::new("test_vertex_type".to_string()).unwrap();
-        let outbound_id = trans.create_vertex(vertex_t.clone()).unwrap();
-        let inbound_id = trans.create_vertex(vertex_t).unwrap();
+        let outbound_id = trans.create_vertex(&vertex_t).unwrap();
+        let inbound_id = trans.create_vertex(&vertex_t).unwrap();
         let key = EdgeKey::new(outbound_id, edge_t, inbound_id);
-        trans.create_edge(key).unwrap();
+        trans.create_edge(&key).unwrap();
         outbound_id
     };
 
@@ -98,7 +98,7 @@ where
         let trans = datastore.transaction().unwrap();
         let edge_t = Type::new("test_vertex_type".to_string()).unwrap();
         trans
-            .get_edge_count(outbound_id, Some(edge_t), EdgeDirection::Outbound)
+            .get_edge_count(outbound_id, Some(&edge_t), EdgeDirection::Outbound)
             .unwrap();
     });
 }

--- a/lib/src/memory/datastore.rs
+++ b/lib/src/memory/datastore.rs
@@ -372,9 +372,7 @@ impl Transaction for MemoryTransaction {
 
         if direction == models::EdgeDirection::Outbound {
             let lower_bound = match type_filter {
-                Some(type_filter) => {
-                    models::EdgeKey::new(id, type_filter.clone(), Uuid::default())
-                }
+                Some(type_filter) => models::EdgeKey::new(id, type_filter.clone(), Uuid::default()),
                 None => {
                     let empty_type = models::Type::default();
                     models::EdgeKey::new(id, empty_type, Uuid::default())
@@ -415,7 +413,9 @@ impl Transaction for MemoryTransaction {
 
     fn set_global_metadata(&self, name: &str, value: &JsonValue) -> Result<()> {
         let mut datastore = self.datastore.write().unwrap();
-        datastore.global_metadata.insert(name.to_string(), value.clone());
+        datastore
+            .global_metadata
+            .insert(name.to_string(), value.clone());
         Ok(())
     }
 
@@ -477,7 +477,9 @@ impl Transaction for MemoryTransaction {
         let edge_values = datastore.get_edge_values_by_query(q)?;
 
         for (key, _) in edge_values {
-            let metadata_value = datastore.edge_metadata.get(&(key.clone(), name.to_string()));
+            let metadata_value = datastore
+                .edge_metadata
+                .get(&(key.clone(), name.to_string()));
 
             if let Some(metadata_value) = metadata_value {
                 result.push(models::EdgeMetadata::new(key, metadata_value.clone()));

--- a/lib/src/memory/datastore.rs
+++ b/lib/src/memory/datastore.rs
@@ -413,9 +413,9 @@ impl Transaction for MemoryTransaction {
         }
     }
 
-    fn set_global_metadata(&self, name: &str, value: JsonValue) -> Result<()> {
+    fn set_global_metadata(&self, name: &str, value: &JsonValue) -> Result<()> {
         let mut datastore = self.datastore.write().unwrap();
-        datastore.global_metadata.insert(name.to_string(), value);
+        datastore.global_metadata.insert(name.to_string(), value.clone());
         Ok(())
     }
 
@@ -445,7 +445,7 @@ impl Transaction for MemoryTransaction {
         Ok(result)
     }
 
-    fn set_vertex_metadata(&self, q: &VertexQuery, name: &str, value: JsonValue) -> Result<()> {
+    fn set_vertex_metadata(&self, q: &VertexQuery, name: &str, value: &JsonValue) -> Result<()> {
         let mut datastore = self.datastore.write().unwrap();
 
         let vertex_values = datastore.get_vertex_values_by_query(q)?;
@@ -487,7 +487,7 @@ impl Transaction for MemoryTransaction {
         Ok(result)
     }
 
-    fn set_edge_metadata(&self, q: &EdgeQuery, name: &str, value: JsonValue) -> Result<()> {
+    fn set_edge_metadata(&self, q: &EdgeQuery, name: &str, value: &JsonValue) -> Result<()> {
         let mut datastore = self.datastore.write().unwrap();
 
         let edge_values = datastore.get_edge_values_by_query(q)?;

--- a/lib/src/memory/datastore.rs
+++ b/lib/src/memory/datastore.rs
@@ -24,9 +24,9 @@ struct InternalMemoryDatastore {
 }
 
 impl InternalMemoryDatastore {
-    fn get_vertex_values_by_query(&self, q: VertexQuery) -> Result<Vec<(Uuid, models::Type)>> {
+    fn get_vertex_values_by_query(&self, q: &VertexQuery) -> Result<Vec<(Uuid, models::Type)>> {
         match q {
-            VertexQuery::All { start_id, limit } => if let Some(start_id) = start_id {
+            &VertexQuery::All { start_id, limit } => if let Some(start_id) = start_id {
                 Ok(self.vertices
                     .range(start_id..)
                     .take(limit as usize)
@@ -39,25 +39,25 @@ impl InternalMemoryDatastore {
                     .map(|(k, v)| (*k, v.clone()))
                     .collect())
             },
-            VertexQuery::Vertices { ids } => {
+            &VertexQuery::Vertices { ref ids } => {
                 let mut results = Vec::new();
 
                 for id in ids {
                     let value = self.vertices.get(&id);
 
                     if let Some(value) = value {
-                        results.push((id, value.clone()));
+                        results.push((*id, value.clone()));
                     }
                 }
 
                 Ok(results)
             }
-            VertexQuery::Pipe {
-                edge_query,
+            &VertexQuery::Pipe {
+                ref edge_query,
                 converter,
                 limit,
             } => {
-                let edge_values = self.get_edge_values_by_query(*edge_query)?;
+                let edge_values = self.get_edge_values_by_query(&*edge_query)?;
 
                 let ids: Vec<Uuid> = match converter.clone() {
                     models::EdgeDirection::Outbound => edge_values
@@ -88,40 +88,40 @@ impl InternalMemoryDatastore {
 
     fn get_edge_values_by_query(
         &self,
-        q: EdgeQuery,
+        q: &EdgeQuery,
     ) -> Result<Vec<(models::EdgeKey, DateTime<Utc>)>> {
         match q {
-            EdgeQuery::Edges { keys } => {
+            &EdgeQuery::Edges { ref keys } => {
                 let mut results = Vec::new();
 
                 for key in keys {
                     let value = self.edges.get(&key);
 
                     if let Some(update_datetime) = value {
-                        results.push((key, *update_datetime));
+                        results.push((key.clone(), *update_datetime));
                     }
                 }
 
                 Ok(results)
             }
-            EdgeQuery::Pipe {
-                vertex_query,
+            &EdgeQuery::Pipe {
+                ref vertex_query,
                 converter,
-                type_filter,
+                ref type_filter,
                 high_filter,
                 low_filter,
                 limit,
             } => {
-                let vertex_values = self.get_vertex_values_by_query(*vertex_query)?;
+                let vertex_values = self.get_vertex_values_by_query(&*vertex_query)?;
                 let mut results = Vec::new();
 
                 match converter {
                     models::EdgeDirection::Outbound => for (id, _) in vertex_values {
                         let lower_bound = match type_filter {
-                            Some(ref type_filter) => {
+                            &Some(ref type_filter) => {
                                 models::EdgeKey::new(id, type_filter.clone(), Uuid::default())
                             }
-                            None => {
+                            &None => {
                                 let empty_type = models::Type::default();
                                 models::EdgeKey::new(id, empty_type, Uuid::default())
                             }
@@ -132,20 +132,20 @@ impl InternalMemoryDatastore {
                                 break;
                             }
 
-                            if let Some(ref type_filter) = type_filter {
+                            if let &Some(ref type_filter) = type_filter {
                                 if &key.t != type_filter {
                                     break;
                                 }
                             }
 
                             if let Some(high_filter) = high_filter {
-                                if *update_datetime > high_filter {
+                                if update_datetime > &high_filter {
                                     continue;
                                 }
                             }
 
                             if let Some(low_filter) = low_filter {
-                                if *update_datetime < low_filter {
+                                if update_datetime < &low_filter {
                                     continue;
                                 }
                             }
@@ -168,20 +168,20 @@ impl InternalMemoryDatastore {
                                 continue;
                             }
 
-                            if let Some(ref type_filter) = type_filter {
+                            if let &Some(ref type_filter) = type_filter {
                                 if &key.t != type_filter {
                                     continue;
                                 }
                             }
 
                             if let Some(high_filter) = high_filter {
-                                if *update_datetime > high_filter {
+                                if update_datetime > &high_filter {
                                     continue;
                                 }
                             }
 
                             if let Some(low_filter) = low_filter {
-                                if *update_datetime < low_filter {
+                                if update_datetime < &low_filter {
                                     continue;
                                 }
                             }
@@ -292,14 +292,14 @@ pub struct MemoryTransaction {
 }
 
 impl Transaction for MemoryTransaction {
-    fn create_vertex(&self, t: models::Type) -> Result<Uuid> {
+    fn create_vertex(&self, t: &models::Type) -> Result<Uuid> {
         let mut datastore = self.datastore.write().unwrap();
         let id = datastore.uuid_generator.next();
-        datastore.vertices.insert(id, t);
+        datastore.vertices.insert(id, t.clone());
         Ok(id)
     }
 
-    fn get_vertices(&self, q: VertexQuery) -> Result<Vec<models::Vertex>> {
+    fn get_vertices(&self, q: &VertexQuery) -> Result<Vec<models::Vertex>> {
         let vertex_values = self.datastore
             .read()
             .unwrap()
@@ -310,7 +310,7 @@ impl Transaction for MemoryTransaction {
         Ok(iter.collect())
     }
 
-    fn delete_vertices(&self, q: VertexQuery) -> Result<()> {
+    fn delete_vertices(&self, q: &VertexQuery) -> Result<()> {
         let mut datastore = self.datastore.write().unwrap();
         let deletable_vertices = datastore
             .get_vertex_values_by_query(q)?
@@ -326,7 +326,7 @@ impl Transaction for MemoryTransaction {
         Ok(datastore.vertices.len() as u64)
     }
 
-    fn create_edge(&self, key: models::EdgeKey) -> Result<bool> {
+    fn create_edge(&self, key: &models::EdgeKey) -> Result<bool> {
         let mut datastore = self.datastore.write().unwrap();
 
         if !datastore.vertices.contains_key(&key.outbound_id)
@@ -335,14 +335,14 @@ impl Transaction for MemoryTransaction {
             return Ok(false);
         }
 
-        datastore.edges.insert(key, Utc::now());
+        datastore.edges.insert(key.clone(), Utc::now());
         Ok(true)
     }
 
-    fn get_edges(&self, q: EdgeQuery) -> Result<Vec<models::Edge>> {
+    fn get_edges(&self, q: &EdgeQuery) -> Result<Vec<models::Edge>> {
         let edge_values = {
             let datastore = self.datastore.read().unwrap();
-            datastore.get_edge_values_by_query(q)?
+            datastore.get_edge_values_by_query(&q)?
         };
 
         let iter = edge_values
@@ -351,10 +351,10 @@ impl Transaction for MemoryTransaction {
         Ok(iter.collect())
     }
 
-    fn delete_edges(&self, q: EdgeQuery) -> Result<()> {
+    fn delete_edges(&self, q: &EdgeQuery) -> Result<()> {
         let mut datastore = self.datastore.write().unwrap();
         let deletable_edges: Vec<models::EdgeKey> = datastore
-            .get_edge_values_by_query(q)?
+            .get_edge_values_by_query(&q)?
             .into_iter()
             .map(|(k, _)| k)
             .collect();
@@ -365,14 +365,14 @@ impl Transaction for MemoryTransaction {
     fn get_edge_count(
         &self,
         id: Uuid,
-        type_filter: Option<models::Type>,
+        type_filter: Option<&models::Type>,
         direction: models::EdgeDirection,
     ) -> Result<u64> {
         let datastore = self.datastore.read().unwrap();
 
         if direction == models::EdgeDirection::Outbound {
             let lower_bound = match type_filter {
-                Some(ref type_filter) => {
+                Some(type_filter) => {
                     models::EdgeKey::new(id, type_filter.clone(), Uuid::default())
                 }
                 None => {
@@ -383,7 +383,7 @@ impl Transaction for MemoryTransaction {
             let range = datastore.edges.range(lower_bound..);
 
             let range = range.take_while(|&(k, _)| {
-                if let Some(ref type_filter) = type_filter {
+                if let Some(type_filter) = type_filter {
                     k.outbound_id == id && &k.t == type_filter
                 } else {
                     k.outbound_id == id
@@ -393,7 +393,7 @@ impl Transaction for MemoryTransaction {
             Ok(range.count() as u64)
         } else {
             let range = datastore.edges.iter().filter(|&(k, _)| {
-                if let Some(ref type_filter) = type_filter {
+                if let Some(type_filter) = type_filter {
                     k.inbound_id == id && &k.t == type_filter
                 } else {
                     k.inbound_id == id
@@ -404,38 +404,38 @@ impl Transaction for MemoryTransaction {
         }
     }
 
-    fn get_global_metadata(&self, name: String) -> Result<Option<JsonValue>> {
+    fn get_global_metadata(&self, name: &str) -> Result<Option<JsonValue>> {
         let datastore = self.datastore.read().unwrap();
 
-        match datastore.global_metadata.get(&name) {
+        match datastore.global_metadata.get(name) {
             Some(value) => Ok(Some(value.clone())),
             None => Ok(None),
         }
     }
 
-    fn set_global_metadata(&self, name: String, value: JsonValue) -> Result<()> {
+    fn set_global_metadata(&self, name: &str, value: JsonValue) -> Result<()> {
         let mut datastore = self.datastore.write().unwrap();
-        datastore.global_metadata.insert(name, value);
+        datastore.global_metadata.insert(name.to_string(), value);
         Ok(())
     }
 
-    fn delete_global_metadata(&self, name: String) -> Result<()> {
+    fn delete_global_metadata(&self, name: &str) -> Result<()> {
         let mut datastore = self.datastore.write().unwrap();
-        datastore.global_metadata.remove(&name);
+        datastore.global_metadata.remove(name);
         Ok(())
     }
 
     fn get_vertex_metadata(
         &self,
-        q: VertexQuery,
-        name: String,
+        q: &VertexQuery,
+        name: &str,
     ) -> Result<Vec<models::VertexMetadata>> {
         let mut result = Vec::new();
         let datastore = self.datastore.read().unwrap();
-        let vertex_values = datastore.get_vertex_values_by_query(q)?;
+        let vertex_values = datastore.get_vertex_values_by_query(&q)?;
 
         for (id, _) in vertex_values {
-            let metadata_value = datastore.vertex_metadata.get(&(id, name.clone()));
+            let metadata_value = datastore.vertex_metadata.get(&(id, name.to_string()));
 
             if let Some(metadata_value) = metadata_value {
                 result.push(models::VertexMetadata::new(id, metadata_value.clone()));
@@ -445,7 +445,7 @@ impl Transaction for MemoryTransaction {
         Ok(result)
     }
 
-    fn set_vertex_metadata(&self, q: VertexQuery, name: String, value: JsonValue) -> Result<()> {
+    fn set_vertex_metadata(&self, q: &VertexQuery, name: &str, value: JsonValue) -> Result<()> {
         let mut datastore = self.datastore.write().unwrap();
 
         let vertex_values = datastore.get_vertex_values_by_query(q)?;
@@ -453,31 +453,31 @@ impl Transaction for MemoryTransaction {
         for (id, _) in vertex_values {
             datastore
                 .vertex_metadata
-                .insert((id, name.clone()), value.clone());
+                .insert((id, name.to_string()), value.clone());
         }
 
         Ok(())
     }
 
-    fn delete_vertex_metadata(&self, q: VertexQuery, name: String) -> Result<()> {
+    fn delete_vertex_metadata(&self, q: &VertexQuery, name: &str) -> Result<()> {
         let mut datastore = self.datastore.write().unwrap();
 
         let vertex_values = datastore.get_vertex_values_by_query(q)?;
 
         for (id, _) in vertex_values {
-            datastore.vertex_metadata.remove(&(id, name.clone()));
+            datastore.vertex_metadata.remove(&(id, name.to_string()));
         }
 
         Ok(())
     }
 
-    fn get_edge_metadata(&self, q: EdgeQuery, name: String) -> Result<Vec<models::EdgeMetadata>> {
+    fn get_edge_metadata(&self, q: &EdgeQuery, name: &str) -> Result<Vec<models::EdgeMetadata>> {
         let mut result = Vec::new();
         let datastore = self.datastore.read().unwrap();
         let edge_values = datastore.get_edge_values_by_query(q)?;
 
         for (key, _) in edge_values {
-            let metadata_value = datastore.edge_metadata.get(&(key.clone(), name.clone()));
+            let metadata_value = datastore.edge_metadata.get(&(key.clone(), name.to_string()));
 
             if let Some(metadata_value) = metadata_value {
                 result.push(models::EdgeMetadata::new(key, metadata_value.clone()));
@@ -487,7 +487,7 @@ impl Transaction for MemoryTransaction {
         Ok(result)
     }
 
-    fn set_edge_metadata(&self, q: EdgeQuery, name: String, value: JsonValue) -> Result<()> {
+    fn set_edge_metadata(&self, q: &EdgeQuery, name: &str, value: JsonValue) -> Result<()> {
         let mut datastore = self.datastore.write().unwrap();
 
         let edge_values = datastore.get_edge_values_by_query(q)?;
@@ -495,19 +495,19 @@ impl Transaction for MemoryTransaction {
         for (key, _) in edge_values {
             datastore
                 .edge_metadata
-                .insert((key, name.clone()), value.clone());
+                .insert((key, name.to_string()), value.clone());
         }
 
         Ok(())
     }
 
-    fn delete_edge_metadata(&self, q: EdgeQuery, name: String) -> Result<()> {
+    fn delete_edge_metadata(&self, q: &EdgeQuery, name: &str) -> Result<()> {
         let mut datastore = self.datastore.write().unwrap();
 
         let edge_values = datastore.get_edge_values_by_query(q)?;
 
         for (key, _) in edge_values {
-            datastore.edge_metadata.remove(&(key, name.clone()));
+            datastore.edge_metadata.remove(&(key, name.to_string()));
         }
 
         Ok(())

--- a/lib/src/models/queries.rs
+++ b/lib/src/models/queries.rs
@@ -12,7 +12,7 @@ use super::edges::EdgeKey;
 /// query to an edge query. `EdgeDirection`s are used to specify which
 /// end of things you want to pipe - either the outbound items or the inbound
 /// items.
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Hash)]
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Hash, Copy)]
 pub enum EdgeDirection {
     #[serde(rename = "outbound")] Outbound,
     #[serde(rename = "inbound")] Inbound,

--- a/lib/src/pg/datastore.rs
+++ b/lib/src/pg/datastore.rs
@@ -394,7 +394,7 @@ impl Transaction for PostgresTransaction {
         Ok(None)
     }
 
-    fn set_global_metadata(&self, name: &str, value: JsonValue) -> Result<()> {
+    fn set_global_metadata(&self, name: &str, value: &JsonValue) -> Result<()> {
         self.trans.execute(
             "
             INSERT INTO global_metadata (name, value)
@@ -403,7 +403,7 @@ impl Transaction for PostgresTransaction {
             DO UPDATE SET value=$2
             RETURNING 1
             ",
-            &[&name, &value],
+            &[&name, value],
         )?;
 
         Ok(())
@@ -439,7 +439,7 @@ impl Transaction for PostgresTransaction {
         Ok(metadata)
     }
 
-    fn set_vertex_metadata(&self, q: &VertexQuery, name: &str, value: JsonValue) -> Result<()> {
+    fn set_vertex_metadata(&self, q: &VertexQuery, name: &str, value: &JsonValue) -> Result<()> {
         let mut sql_query_builder = CTEQueryBuilder::new();
         self.vertex_query_to_sql(q, &mut sql_query_builder);
         let (query, params) = sql_query_builder.into_query_payload(
@@ -449,7 +449,7 @@ impl Transaction for PostgresTransaction {
             ON CONFLICT ON CONSTRAINT vertex_metadata_pkey
             DO UPDATE SET value=%p
             ",
-            vec![Box::new(name.to_string()), Box::new(value.clone()), Box::new(value)],
+            vec![Box::new(name.to_string()), Box::new(value.clone()), Box::new(value.clone())],
         );
         let params_refs: Vec<&ToSql> = params.iter().map(|x| &**x).collect();
         self.trans.execute(&query[..], &params_refs[..])?;
@@ -498,7 +498,7 @@ impl Transaction for PostgresTransaction {
         Ok(metadata)
     }
 
-    fn set_edge_metadata(&self, q: &EdgeQuery, name: &str, value: JsonValue) -> Result<()> {
+    fn set_edge_metadata(&self, q: &EdgeQuery, name: &str, value: &JsonValue) -> Result<()> {
         let mut sql_query_builder = CTEQueryBuilder::new();
         self.edge_query_to_sql(q, &mut sql_query_builder);
         let (query, params) = sql_query_builder.into_query_payload(
@@ -508,7 +508,7 @@ impl Transaction for PostgresTransaction {
             ON CONFLICT ON CONSTRAINT edge_metadata_pkey
             DO UPDATE SET value=%p
             ",
-            vec![Box::new(name.to_string()), Box::new(value.clone()), Box::new(value)],
+            vec![Box::new(name.to_string()), Box::new(value.clone()), Box::new(value.clone())],
         );
         let params_refs: Vec<&ToSql> = params.iter().map(|x| &**x).collect();
         self.trans.execute(&query[..], &params_refs[..])?;

--- a/lib/src/pg/datastore.rs
+++ b/lib/src/pg/datastore.rs
@@ -111,7 +111,10 @@ impl PostgresTransaction {
 
     fn vertex_query_to_sql(&self, q: &VertexQuery, sql_query_builder: &mut CTEQueryBuilder) {
         match q {
-            &VertexQuery::All { ref start_id, ref limit } => match start_id {
+            &VertexQuery::All {
+                ref start_id,
+                ref limit,
+            } => match start_id {
                 &Some(start_id) => {
                     let query_template =
                         "SELECT id, type FROM %t WHERE id > %p ORDER BY id LIMIT %p";
@@ -449,7 +452,11 @@ impl Transaction for PostgresTransaction {
             ON CONFLICT ON CONSTRAINT vertex_metadata_pkey
             DO UPDATE SET value=%p
             ",
-            vec![Box::new(name.to_string()), Box::new(value.clone()), Box::new(value.clone())],
+            vec![
+                Box::new(name.to_string()),
+                Box::new(value.clone()),
+                Box::new(value.clone()),
+            ],
         );
         let params_refs: Vec<&ToSql> = params.iter().map(|x| &**x).collect();
         self.trans.execute(&query[..], &params_refs[..])?;
@@ -508,7 +515,11 @@ impl Transaction for PostgresTransaction {
             ON CONFLICT ON CONSTRAINT edge_metadata_pkey
             DO UPDATE SET value=%p
             ",
-            vec![Box::new(name.to_string()), Box::new(value.clone()), Box::new(value.clone())],
+            vec![
+                Box::new(name.to_string()),
+                Box::new(value.clone()),
+                Box::new(value.clone()),
+            ],
         );
         let params_refs: Vec<&ToSql> = params.iter().map(|x| &**x).collect();
         self.trans.execute(&query[..], &params_refs[..])?;

--- a/lib/src/pg/datastore.rs
+++ b/lib/src/pg/datastore.rs
@@ -109,28 +109,28 @@ impl PostgresTransaction {
         })
     }
 
-    fn vertex_query_to_sql(&self, q: VertexQuery, sql_query_builder: &mut CTEQueryBuilder) {
+    fn vertex_query_to_sql(&self, q: &VertexQuery, sql_query_builder: &mut CTEQueryBuilder) {
         match q {
-            VertexQuery::All { start_id, limit } => match start_id {
-                Some(start_id) => {
+            &VertexQuery::All { ref start_id, ref limit } => match start_id {
+                &Some(start_id) => {
                     let query_template =
                         "SELECT id, type FROM %t WHERE id > %p ORDER BY id LIMIT %p";
-                    let params: Vec<Box<ToSql>> = vec![Box::new(start_id), Box::new(limit as i64)];
+                    let params: Vec<Box<ToSql>> = vec![Box::new(start_id), Box::new(*limit as i64)];
                     sql_query_builder.push(query_template, "vertices", params);
                 }
-                None => {
+                &None => {
                     let query_template = "SELECT id, type FROM %t ORDER BY id LIMIT %p";
-                    let params: Vec<Box<ToSql>> = vec![Box::new(limit as i64)];
+                    let params: Vec<Box<ToSql>> = vec![Box::new(*limit as i64)];
                     sql_query_builder.push(query_template, "vertices", params);
                 }
             },
-            VertexQuery::Vertices { ids } => {
+            &VertexQuery::Vertices { ref ids } => {
                 let mut params_template_builder = vec![];
                 let mut params: Vec<Box<ToSql>> = vec![];
 
                 for id in ids {
                     params_template_builder.push("%p");
-                    params.push(Box::new(id));
+                    params.push(Box::new(*id));
                 }
 
                 let query_template = format!(
@@ -139,19 +139,19 @@ impl PostgresTransaction {
                 );
                 sql_query_builder.push(&query_template[..], "vertices", params);
             }
-            VertexQuery::Pipe {
-                edge_query,
-                converter,
-                limit,
+            &VertexQuery::Pipe {
+                ref edge_query,
+                ref converter,
+                ref limit,
             } => {
-                self.edge_query_to_sql(*edge_query, sql_query_builder);
-                let params: Vec<Box<ToSql>> = vec![Box::new(limit as i64)];
+                self.edge_query_to_sql(edge_query, sql_query_builder);
+                let params: Vec<Box<ToSql>> = vec![Box::new(*limit as i64)];
 
                 let query_template = match converter {
-                    EdgeDirection::Outbound => {
+                    &EdgeDirection::Outbound => {
                         "SELECT id, type FROM vertices WHERE id IN (SELECT outbound_id FROM %t) ORDER BY id LIMIT %p"
                     }
-                    EdgeDirection::Inbound => {
+                    &EdgeDirection::Inbound => {
                         "SELECT id, type FROM vertices WHERE id IN (SELECT inbound_id FROM %t) ORDER BY id LIMIT %p"
                     }
                 };
@@ -161,16 +161,16 @@ impl PostgresTransaction {
         }
     }
 
-    fn edge_query_to_sql(&self, q: EdgeQuery, sql_query_builder: &mut CTEQueryBuilder) {
+    fn edge_query_to_sql(&self, q: &EdgeQuery, sql_query_builder: &mut CTEQueryBuilder) {
         match q {
-            EdgeQuery::Edges { keys } => {
+            &EdgeQuery::Edges { ref keys } => {
                 let mut params_template_builder = vec![];
                 let mut params: Vec<Box<ToSql>> = vec![];
 
                 for key in keys {
                     params_template_builder.push("(%p, %p, %p)");
                     params.push(Box::new(key.outbound_id));
-                    params.push(Box::new(key.t.0));
+                    params.push(Box::new(key.t.0.to_string()));
                     params.push(Box::new(key.inbound_id));
                 }
 
@@ -180,22 +180,22 @@ impl PostgresTransaction {
                 );
                 sql_query_builder.push(&query_template[..], "edges", params);
             }
-            EdgeQuery::Pipe {
-                vertex_query,
+            &EdgeQuery::Pipe {
+                ref vertex_query,
                 converter,
-                type_filter,
+                ref type_filter,
                 high_filter,
                 low_filter,
                 limit,
             } => {
-                self.vertex_query_to_sql(*vertex_query, sql_query_builder);
+                self.vertex_query_to_sql(&*vertex_query, sql_query_builder);
 
                 let mut where_clause_template_builder = vec![];
                 let mut params: Vec<Box<ToSql>> = vec![];
 
-                if let Some(type_filter) = type_filter {
+                if let &Some(ref type_filter) = type_filter {
                     where_clause_template_builder.push("type = %p");
-                    params.push(Box::new(type_filter.0));
+                    params.push(Box::new(type_filter.0.to_string()));
                 }
 
                 if let Some(high_filter) = high_filter {
@@ -239,7 +239,7 @@ impl PostgresTransaction {
 }
 
 impl Transaction for PostgresTransaction {
-    fn create_vertex(&self, t: models::Type) -> Result<Uuid> {
+    fn create_vertex(&self, t: &models::Type) -> Result<Uuid> {
         let id = self.uuid_generator.next();
         self.trans.execute(
             "INSERT INTO vertices (id, type) VALUES ($1, $2)",
@@ -248,7 +248,7 @@ impl Transaction for PostgresTransaction {
         Ok(id)
     }
 
-    fn get_vertices(&self, q: VertexQuery) -> Result<Vec<models::Vertex>> {
+    fn get_vertices(&self, q: &VertexQuery) -> Result<Vec<models::Vertex>> {
         let mut sql_query_builder = CTEQueryBuilder::new();
         self.vertex_query_to_sql(q, &mut sql_query_builder);
         let (query, params) =
@@ -268,7 +268,7 @@ impl Transaction for PostgresTransaction {
         Ok(vertices)
     }
 
-    fn delete_vertices(&self, q: VertexQuery) -> Result<()> {
+    fn delete_vertices(&self, q: &VertexQuery) -> Result<()> {
         let mut sql_query_builder = CTEQueryBuilder::new();
         self.vertex_query_to_sql(q, &mut sql_query_builder);
         let (query, params) = sql_query_builder.into_query_payload(
@@ -291,7 +291,7 @@ impl Transaction for PostgresTransaction {
         unreachable!();
     }
 
-    fn create_edge(&self, key: models::EdgeKey) -> Result<bool> {
+    fn create_edge(&self, key: &models::EdgeKey) -> Result<bool> {
         let id = self.uuid_generator.next();
 
         // Because this command could fail, we need to set a savepoint to roll
@@ -317,7 +317,7 @@ impl Transaction for PostgresTransaction {
         }
     }
 
-    fn get_edges(&self, q: EdgeQuery) -> Result<Vec<models::Edge>> {
+    fn get_edges(&self, q: &EdgeQuery) -> Result<Vec<models::Edge>> {
         let mut sql_query_builder = CTEQueryBuilder::new();
         self.edge_query_to_sql(q, &mut sql_query_builder);
         let (query, params) = sql_query_builder.into_query_payload(
@@ -343,7 +343,7 @@ impl Transaction for PostgresTransaction {
         Ok(edges)
     }
 
-    fn delete_edges(&self, q: EdgeQuery) -> Result<()> {
+    fn delete_edges(&self, q: &EdgeQuery) -> Result<()> {
         let mut sql_query_builder = CTEQueryBuilder::new();
         self.edge_query_to_sql(q, &mut sql_query_builder);
         let (query, params) = sql_query_builder
@@ -356,7 +356,7 @@ impl Transaction for PostgresTransaction {
     fn get_edge_count(
         &self,
         id: Uuid,
-        type_filter: Option<models::Type>,
+        type_filter: Option<&models::Type>,
         direction: models::EdgeDirection,
     ) -> Result<u64> {
         let results = match (direction, type_filter) {
@@ -382,7 +382,7 @@ impl Transaction for PostgresTransaction {
         unreachable!();
     }
 
-    fn get_global_metadata(&self, name: String) -> Result<Option<JsonValue>> {
+    fn get_global_metadata(&self, name: &str) -> Result<Option<JsonValue>> {
         let results = self.trans
             .query("SELECT value FROM global_metadata WHERE name=$1", &[&name])?;
 
@@ -394,7 +394,7 @@ impl Transaction for PostgresTransaction {
         Ok(None)
     }
 
-    fn set_global_metadata(&self, name: String, value: JsonValue) -> Result<()> {
+    fn set_global_metadata(&self, name: &str, value: JsonValue) -> Result<()> {
         self.trans.execute(
             "
             INSERT INTO global_metadata (name, value)
@@ -409,7 +409,7 @@ impl Transaction for PostgresTransaction {
         Ok(())
     }
 
-    fn delete_global_metadata(&self, name: String) -> Result<()> {
+    fn delete_global_metadata(&self, name: &str) -> Result<()> {
         self.trans.execute(
             "DELETE FROM global_metadata WHERE name=$1 RETURNING 1",
             &[&name],
@@ -420,12 +420,12 @@ impl Transaction for PostgresTransaction {
 
     fn get_vertex_metadata(
         &self,
-        q: VertexQuery,
-        name: String,
+        q: &VertexQuery,
+        name: &str,
     ) -> Result<Vec<models::VertexMetadata>> {
         let mut sql_query_builder = CTEQueryBuilder::new();
         self.vertex_query_to_sql(q, &mut sql_query_builder);
-        let (query, params) = sql_query_builder.into_query_payload("SELECT owner_id, value FROM vertex_metadata WHERE owner_id IN (SELECT id FROM %t) AND name=%p", vec![Box::new(name)]);
+        let (query, params) = sql_query_builder.into_query_payload("SELECT owner_id, value FROM vertex_metadata WHERE owner_id IN (SELECT id FROM %t) AND name=%p", vec![Box::new(name.to_string())]);
         let params_refs: Vec<&ToSql> = params.iter().map(|x| &**x).collect();
         let results = self.trans.query(&query[..], &params_refs[..])?;
         let mut metadata = Vec::new();
@@ -439,7 +439,7 @@ impl Transaction for PostgresTransaction {
         Ok(metadata)
     }
 
-    fn set_vertex_metadata(&self, q: VertexQuery, name: String, value: JsonValue) -> Result<()> {
+    fn set_vertex_metadata(&self, q: &VertexQuery, name: &str, value: JsonValue) -> Result<()> {
         let mut sql_query_builder = CTEQueryBuilder::new();
         self.vertex_query_to_sql(q, &mut sql_query_builder);
         let (query, params) = sql_query_builder.into_query_payload(
@@ -449,26 +449,26 @@ impl Transaction for PostgresTransaction {
             ON CONFLICT ON CONSTRAINT vertex_metadata_pkey
             DO UPDATE SET value=%p
             ",
-            vec![Box::new(name), Box::new(value.clone()), Box::new(value)],
+            vec![Box::new(name.to_string()), Box::new(value.clone()), Box::new(value)],
         );
         let params_refs: Vec<&ToSql> = params.iter().map(|x| &**x).collect();
         self.trans.execute(&query[..], &params_refs[..])?;
         Ok(())
     }
 
-    fn delete_vertex_metadata(&self, q: VertexQuery, name: String) -> Result<()> {
+    fn delete_vertex_metadata(&self, q: &VertexQuery, name: &str) -> Result<()> {
         let mut sql_query_builder = CTEQueryBuilder::new();
         self.vertex_query_to_sql(q, &mut sql_query_builder);
         let (query, params) = sql_query_builder.into_query_payload(
             "DELETE FROM vertex_metadata WHERE owner_id IN (SELECT id FROM %t) AND name=%p",
-            vec![Box::new(name)],
+            vec![Box::new(name.to_string())],
         );
         let params_refs: Vec<&ToSql> = params.iter().map(|x| &**x).collect();
         self.trans.execute(&query[..], &params_refs[..])?;
         Ok(())
     }
 
-    fn get_edge_metadata(&self, q: EdgeQuery, name: String) -> Result<Vec<models::EdgeMetadata>> {
+    fn get_edge_metadata(&self, q: &EdgeQuery, name: &str) -> Result<Vec<models::EdgeMetadata>> {
         let mut sql_query_builder = CTEQueryBuilder::new();
         self.edge_query_to_sql(q, &mut sql_query_builder);
 
@@ -478,7 +478,7 @@ impl Transaction for PostgresTransaction {
             FROM edge_metadata JOIN edges ON edge_metadata.owner_id=edges.id
             WHERE owner_id IN (SELECT id FROM %t) AND name=%p
             ",
-            vec![Box::new(name)],
+            vec![Box::new(name.to_string())],
         );
 
         let params_refs: Vec<&ToSql> = params.iter().map(|x| &**x).collect();
@@ -498,7 +498,7 @@ impl Transaction for PostgresTransaction {
         Ok(metadata)
     }
 
-    fn set_edge_metadata(&self, q: EdgeQuery, name: String, value: JsonValue) -> Result<()> {
+    fn set_edge_metadata(&self, q: &EdgeQuery, name: &str, value: JsonValue) -> Result<()> {
         let mut sql_query_builder = CTEQueryBuilder::new();
         self.edge_query_to_sql(q, &mut sql_query_builder);
         let (query, params) = sql_query_builder.into_query_payload(
@@ -508,19 +508,19 @@ impl Transaction for PostgresTransaction {
             ON CONFLICT ON CONSTRAINT edge_metadata_pkey
             DO UPDATE SET value=%p
             ",
-            vec![Box::new(name), Box::new(value.clone()), Box::new(value)],
+            vec![Box::new(name.to_string()), Box::new(value.clone()), Box::new(value)],
         );
         let params_refs: Vec<&ToSql> = params.iter().map(|x| &**x).collect();
         self.trans.execute(&query[..], &params_refs[..])?;
         Ok(())
     }
 
-    fn delete_edge_metadata(&self, q: EdgeQuery, name: String) -> Result<()> {
+    fn delete_edge_metadata(&self, q: &EdgeQuery, name: &str) -> Result<()> {
         let mut sql_query_builder = CTEQueryBuilder::new();
         self.edge_query_to_sql(q, &mut sql_query_builder);
         let (query, params) = sql_query_builder.into_query_payload(
             "DELETE FROM edge_metadata WHERE owner_id IN (SELECT id FROM %t) AND name=%p",
-            vec![Box::new(name)],
+            vec![Box::new(name.to_string())],
         );
         let params_refs: Vec<&ToSql> = params.iter().map(|x| &**x).collect();
         self.trans.execute(&query[..], &params_refs[..])?;

--- a/lib/src/rdb/datastore.rs
+++ b/lib/src/rdb/datastore.rs
@@ -456,9 +456,9 @@ impl Transaction for RocksdbTransaction {
         manager.get(&name[..])
     }
 
-    fn set_global_metadata(&self, name: &str, value: JsonValue) -> Result<()> {
+    fn set_global_metadata(&self, name: &str, value: &JsonValue) -> Result<()> {
         let manager = GlobalMetadataManager::new(self.db.clone());
-        manager.set(&name[..], &value)
+        manager.set(&name[..], value)
     }
 
     fn delete_global_metadata(&self, name: &str) -> Result<()> {
@@ -488,13 +488,13 @@ impl Transaction for RocksdbTransaction {
         Ok(metadata)
     }
 
-    fn set_vertex_metadata(&self, q: &VertexQuery, name: &str, value: JsonValue) -> Result<()> {
+    fn set_vertex_metadata(&self, q: &VertexQuery, name: &str, value: &JsonValue) -> Result<()> {
         let manager = VertexMetadataManager::new(self.db.clone());
         let mut batch = WriteBatch::default();
 
         for item in self.vertex_query_to_iterator(q)? {
             let (id, _) = item?;
-            manager.set(&mut batch, id, &name[..], &value)?;
+            manager.set(&mut batch, id, &name[..], value)?;
         }
 
         self.db.write(batch)?;
@@ -531,13 +531,13 @@ impl Transaction for RocksdbTransaction {
         Ok(metadata)
     }
 
-    fn set_edge_metadata(&self, q: &EdgeQuery, name: &str, value: JsonValue) -> Result<()> {
+    fn set_edge_metadata(&self, q: &EdgeQuery, name: &str, value: &JsonValue) -> Result<()> {
         let manager = EdgeMetadataManager::new(self.db.clone());
         let mut batch = WriteBatch::default();
 
         for item in self.edge_query_to_iterator(q)? {
             let (outbound_id, t, _, inbound_id) = item?;
-            manager.set(&mut batch, outbound_id, &t, inbound_id, &name[..], &value)?;
+            manager.set(&mut batch, outbound_id, &t, inbound_id, &name[..], value)?;
         }
 
         self.db.write(batch)?;

--- a/lib/src/rdb/datastore.rs
+++ b/lib/src/rdb/datastore.rs
@@ -124,7 +124,10 @@ impl RocksdbTransaction {
         })
     }
 
-    fn vertex_query_to_iterator(&self, q: &VertexQuery) -> Result<Box<Iterator<Item = VertexItem>>> {
+    fn vertex_query_to_iterator(
+        &self,
+        q: &VertexQuery,
+    ) -> Result<Box<Iterator<Item = VertexItem>>> {
         let vertex_manager = VertexManager::new(self.db.clone(), self.uuid_generator.clone());
 
         match q {
@@ -181,17 +184,21 @@ impl RocksdbTransaction {
             &EdgeQuery::Edges { ref keys } => {
                 let edge_manager = EdgeManager::new(self.db.clone());
 
-                let edges: Vec<Result<Option<(Uuid, models::Type, DateTime<Utc>, Uuid)>>> = keys.into_iter().map(move |key| {
-                    match edge_manager.get(key.outbound_id, &key.t, key.inbound_id)? {
-                        Some(update_datetime) => Ok(Some((
-                            key.outbound_id,
-                            key.t.clone(),
-                            update_datetime,
-                            key.inbound_id,
-                        ))),
-                        None => Ok(None),
-                    }
-                }).collect();
+                let edges: Vec<
+                    Result<Option<(Uuid, models::Type, DateTime<Utc>, Uuid)>>,
+                > = keys.into_iter()
+                    .map(move |key| {
+                        match edge_manager.get(key.outbound_id, &key.t, key.inbound_id)? {
+                            Some(update_datetime) => Ok(Some((
+                                key.outbound_id,
+                                key.t.clone(),
+                                update_datetime,
+                                key.inbound_id,
+                            ))),
+                            None => Ok(None),
+                        }
+                    })
+                    .collect();
 
                 let iterator = self.remove_nones_from_iterator(Box::new(edges.into_iter()));
                 Ok(iterator)
@@ -221,8 +228,11 @@ impl RocksdbTransaction {
                 if let Some(low_filter) = low_filter {
                     for item in vertex_iterator {
                         let (id, _) = item?;
-                        let edge_iterator =
-                            edge_range_manager.iterate_for_range(id, type_filter.as_ref(), high_filter)?;
+                        let edge_iterator = edge_range_manager.iterate_for_range(
+                            id,
+                            type_filter.as_ref(),
+                            high_filter,
+                        )?;
 
                         for item in edge_iterator {
                             match item {
@@ -262,8 +272,11 @@ impl RocksdbTransaction {
                 } else {
                     for item in vertex_iterator {
                         let (id, _) = item?;
-                        let edge_iterator =
-                            edge_range_manager.iterate_for_range(id, type_filter.as_ref(), high_filter)?;
+                        let edge_iterator = edge_range_manager.iterate_for_range(
+                            id,
+                            type_filter.as_ref(),
+                            high_filter,
+                        )?;
 
                         for item in edge_iterator {
                             match item {

--- a/lib/src/rdb/datastore.rs
+++ b/lib/src/rdb/datastore.rs
@@ -13,6 +13,7 @@ use std::u64;
 use super::managers::*;
 use core::fmt::Debug;
 use util::UuidGenerator;
+use chrono::DateTime;
 
 const CF_NAMES: [&'static str; 7] = [
     "vertices:v1",
@@ -123,11 +124,11 @@ impl RocksdbTransaction {
         })
     }
 
-    fn vertex_query_to_iterator(&self, q: VertexQuery) -> Result<Box<Iterator<Item = VertexItem>>> {
+    fn vertex_query_to_iterator(&self, q: &VertexQuery) -> Result<Box<Iterator<Item = VertexItem>>> {
         let vertex_manager = VertexManager::new(self.db.clone(), self.uuid_generator.clone());
 
         match q {
-            VertexQuery::All { start_id, limit } => {
+            &VertexQuery::All { start_id, limit } => {
                 let next_uuid = match start_id {
                     Some(start_id) => {
                         match next_uuid(start_id) {
@@ -146,17 +147,17 @@ impl RocksdbTransaction {
                 let iterator = vertex_manager.iterate_for_range(next_uuid)?;
                 Ok(Box::new(iterator.take(limit as usize)))
             }
-            VertexQuery::Vertices { ids } => {
-                let iterator = Box::new(ids.into_iter().map(|item| Ok(item)));
-
+            &VertexQuery::Vertices { ref ids } => {
+                let vertices: Vec<Result<Uuid>> = ids.into_iter().map(|id| Ok(*id)).collect();
+                let iterator = Box::new(vertices.into_iter());
                 Ok(self.handle_vertex_id_iterator(iterator))
             }
-            VertexQuery::Pipe {
-                edge_query,
+            &VertexQuery::Pipe {
+                ref edge_query,
                 converter,
                 limit,
             } => {
-                let edge_iterator = self.edge_query_to_iterator(*edge_query)?;
+                let edge_iterator = self.edge_query_to_iterator(edge_query)?;
 
                 let vertex_id_iterator = Box::new(edge_iterator.map(move |item| {
                     let (outbound_id, _, _, inbound_id) = item?;
@@ -175,34 +176,35 @@ impl RocksdbTransaction {
         }
     }
 
-    fn edge_query_to_iterator(&self, q: EdgeQuery) -> Result<Box<Iterator<Item = EdgeRangeItem>>> {
+    fn edge_query_to_iterator(&self, q: &EdgeQuery) -> Result<Box<Iterator<Item = EdgeRangeItem>>> {
         match q {
-            EdgeQuery::Edges { keys } => {
+            &EdgeQuery::Edges { ref keys } => {
                 let edge_manager = EdgeManager::new(self.db.clone());
 
-                let iterator = keys.into_iter().map(move |key| {
+                let edges: Vec<Result<Option<(Uuid, models::Type, DateTime<Utc>, Uuid)>>> = keys.into_iter().map(move |key| {
                     match edge_manager.get(key.outbound_id, &key.t, key.inbound_id)? {
                         Some(update_datetime) => Ok(Some((
                             key.outbound_id,
-                            key.t,
+                            key.t.clone(),
                             update_datetime,
                             key.inbound_id,
                         ))),
                         None => Ok(None),
                     }
-                });
+                }).collect();
 
-                Ok(self.remove_nones_from_iterator(Box::new(iterator)))
+                let iterator = self.remove_nones_from_iterator(Box::new(edges.into_iter()));
+                Ok(iterator)
             }
-            EdgeQuery::Pipe {
-                vertex_query,
+            &EdgeQuery::Pipe {
+                ref vertex_query,
                 converter,
-                type_filter,
+                ref type_filter,
                 high_filter,
                 low_filter,
                 limit,
             } => {
-                let vertex_iterator = self.vertex_query_to_iterator(*vertex_query)?;
+                let vertex_iterator = self.vertex_query_to_iterator(&*vertex_query)?;
 
                 let edge_range_manager = match converter {
                     EdgeDirection::Outbound => EdgeRangeManager::new(self.db.clone()),
@@ -220,7 +222,7 @@ impl RocksdbTransaction {
                     for item in vertex_iterator {
                         let (id, _) = item?;
                         let edge_iterator =
-                            edge_range_manager.iterate_for_range(id, &type_filter, high_filter)?;
+                            edge_range_manager.iterate_for_range(id, type_filter.as_ref(), high_filter)?;
 
                         for item in edge_iterator {
                             match item {
@@ -261,7 +263,7 @@ impl RocksdbTransaction {
                     for item in vertex_iterator {
                         let (id, _) = item?;
                         let edge_iterator =
-                            edge_range_manager.iterate_for_range(id, &type_filter, high_filter)?;
+                            edge_range_manager.iterate_for_range(id, type_filter.as_ref(), high_filter)?;
 
                         for item in edge_iterator {
                             match item {
@@ -344,11 +346,11 @@ impl RocksdbTransaction {
 }
 
 impl Transaction for RocksdbTransaction {
-    fn create_vertex(&self, t: models::Type) -> Result<Uuid> {
+    fn create_vertex(&self, t: &models::Type) -> Result<Uuid> {
         VertexManager::new(self.db.clone(), self.uuid_generator.clone()).create(t)
     }
 
-    fn get_vertices(&self, q: VertexQuery) -> Result<Vec<models::Vertex>> {
+    fn get_vertices(&self, q: &VertexQuery) -> Result<Vec<models::Vertex>> {
         let iterator = self.vertex_query_to_iterator(q)?;
 
         let mapped = iterator.map(move |item| {
@@ -360,7 +362,7 @@ impl Transaction for RocksdbTransaction {
         mapped.collect()
     }
 
-    fn delete_vertices(&self, q: VertexQuery) -> Result<()> {
+    fn delete_vertices(&self, q: &VertexQuery) -> Result<()> {
         let iterator = self.vertex_query_to_iterator(q)?;
         let vertex_manager = VertexManager::new(self.db.clone(), self.uuid_generator.clone());
         let mut batch = WriteBatch::default();
@@ -380,7 +382,7 @@ impl Transaction for RocksdbTransaction {
         Ok(iterator.count() as u64)
     }
 
-    fn create_edge(&self, key: models::EdgeKey) -> Result<bool> {
+    fn create_edge(&self, key: &models::EdgeKey) -> Result<bool> {
         // Verify that the vertices exist and that we own the vertex with the outbound ID
         if !VertexManager::new(self.db.clone(), self.uuid_generator.clone()).exists(key.inbound_id)?
         {
@@ -400,7 +402,7 @@ impl Transaction for RocksdbTransaction {
         Ok(true)
     }
 
-    fn get_edges(&self, q: EdgeQuery) -> Result<Vec<models::Edge>> {
+    fn get_edges(&self, q: &EdgeQuery) -> Result<Vec<models::Edge>> {
         let iterator = self.edge_query_to_iterator(q)?;
 
         let mapped = iterator.map(move |item| {
@@ -413,7 +415,7 @@ impl Transaction for RocksdbTransaction {
         mapped.collect()
     }
 
-    fn delete_edges(&self, q: EdgeQuery) -> Result<()> {
+    fn delete_edges(&self, q: &EdgeQuery) -> Result<()> {
         let edge_manager = EdgeManager::new(self.db.clone());
         let vertex_manager = VertexManager::new(self.db.clone(), self.uuid_generator.clone());
         let iterator = self.edge_query_to_iterator(q)?;
@@ -434,7 +436,7 @@ impl Transaction for RocksdbTransaction {
     fn get_edge_count(
         &self,
         id: Uuid,
-        type_filter: Option<models::Type>,
+        type_filter: Option<&models::Type>,
         direction: models::EdgeDirection,
     ) -> Result<u64> {
         let edge_range_manager = match direction {
@@ -443,23 +445,23 @@ impl Transaction for RocksdbTransaction {
         };
 
         let count = edge_range_manager
-            .iterate_for_range(id, &type_filter, None)?
+            .iterate_for_range(id, type_filter, None)?
             .count();
 
         Ok(count as u64)
     }
 
-    fn get_global_metadata(&self, name: String) -> Result<Option<JsonValue>> {
+    fn get_global_metadata(&self, name: &str) -> Result<Option<JsonValue>> {
         let manager = GlobalMetadataManager::new(self.db.clone());
         manager.get(&name[..])
     }
 
-    fn set_global_metadata(&self, name: String, value: JsonValue) -> Result<()> {
+    fn set_global_metadata(&self, name: &str, value: JsonValue) -> Result<()> {
         let manager = GlobalMetadataManager::new(self.db.clone());
         manager.set(&name[..], &value)
     }
 
-    fn delete_global_metadata(&self, name: String) -> Result<()> {
+    fn delete_global_metadata(&self, name: &str) -> Result<()> {
         let mut batch = WriteBatch::default();
         GlobalMetadataManager::new(self.db.clone()).delete(&mut batch, &name[..])?;
         self.db.write(batch)?;
@@ -468,8 +470,8 @@ impl Transaction for RocksdbTransaction {
 
     fn get_vertex_metadata(
         &self,
-        q: VertexQuery,
-        name: String,
+        q: &VertexQuery,
+        name: &str,
     ) -> Result<Vec<models::VertexMetadata>> {
         let manager = VertexMetadataManager::new(self.db.clone());
         let mut metadata = Vec::new();
@@ -486,7 +488,7 @@ impl Transaction for RocksdbTransaction {
         Ok(metadata)
     }
 
-    fn set_vertex_metadata(&self, q: VertexQuery, name: String, value: JsonValue) -> Result<()> {
+    fn set_vertex_metadata(&self, q: &VertexQuery, name: &str, value: JsonValue) -> Result<()> {
         let manager = VertexMetadataManager::new(self.db.clone());
         let mut batch = WriteBatch::default();
 
@@ -499,7 +501,7 @@ impl Transaction for RocksdbTransaction {
         Ok(())
     }
 
-    fn delete_vertex_metadata(&self, q: VertexQuery, name: String) -> Result<()> {
+    fn delete_vertex_metadata(&self, q: &VertexQuery, name: &str) -> Result<()> {
         let manager = VertexMetadataManager::new(self.db.clone());
         let mut batch = WriteBatch::default();
 
@@ -512,7 +514,7 @@ impl Transaction for RocksdbTransaction {
         Ok(())
     }
 
-    fn get_edge_metadata(&self, q: EdgeQuery, name: String) -> Result<Vec<models::EdgeMetadata>> {
+    fn get_edge_metadata(&self, q: &EdgeQuery, name: &str) -> Result<Vec<models::EdgeMetadata>> {
         let manager = EdgeMetadataManager::new(self.db.clone());
         let mut metadata = Vec::new();
 
@@ -529,7 +531,7 @@ impl Transaction for RocksdbTransaction {
         Ok(metadata)
     }
 
-    fn set_edge_metadata(&self, q: EdgeQuery, name: String, value: JsonValue) -> Result<()> {
+    fn set_edge_metadata(&self, q: &EdgeQuery, name: &str, value: JsonValue) -> Result<()> {
         let manager = EdgeMetadataManager::new(self.db.clone());
         let mut batch = WriteBatch::default();
 
@@ -542,7 +544,7 @@ impl Transaction for RocksdbTransaction {
         Ok(())
     }
 
-    fn delete_edge_metadata(&self, q: EdgeQuery, name: String) -> Result<()> {
+    fn delete_edge_metadata(&self, q: &EdgeQuery, name: &str) -> Result<()> {
         let manager = EdgeMetadataManager::new(self.db.clone());
         let mut batch = WriteBatch::default();
 

--- a/lib/src/rdb/managers.rs
+++ b/lib/src/rdb/managers.rs
@@ -141,9 +141,9 @@ impl VertexManager {
         self.iterate(iterator)
     }
 
-    pub fn create(&self, t: models::Type) -> Result<Uuid> {
+    pub fn create(&self, t: &models::Type) -> Result<Uuid> {
         let id = self.uuid_generator.next();
-        set_bincode(&self.db, self.cf, self.key(id), &t)?;
+        set_bincode(&self.db, self.cf, self.key(id), t)?;
         Ok(id)
     }
 
@@ -384,11 +384,11 @@ impl EdgeRangeManager {
     pub fn iterate_for_range<'a>(
         &self,
         id: Uuid,
-        t: &Option<models::Type>,
+        t: Option<&models::Type>,
         high: Option<DateTime<Utc>>,
     ) -> Result<Box<Iterator<Item = EdgeRangeItem> + 'a>> {
-        match *t {
-            Some(ref t) => {
+        match t {
+            Some(t) => {
                 let high = high.unwrap_or_else(|| *MAX_DATETIME);
                 let prefix = build_key(vec![KeyComponent::Uuid(id), KeyComponent::Type(t)]);
                 let low_key = build_key(vec![

--- a/lib/src/tests/edge.rs
+++ b/lib/src/tests/edge.rs
@@ -14,8 +14,8 @@ where
     let trans = datastore.transaction().unwrap();
 
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
-    let outbound_id = trans.create_vertex(vertex_t.clone()).unwrap();
-    let inbound_id = trans.create_vertex(vertex_t).unwrap();
+    let outbound_id = trans.create_vertex(&vertex_t).unwrap();
+    let inbound_id = trans.create_vertex(&vertex_t).unwrap();
     let edge_t = models::Type::new("test_edge_type".to_string()).unwrap();
     let key = models::EdgeKey::new(outbound_id, edge_t.clone(), inbound_id);
 
@@ -23,11 +23,11 @@ where
     // start time, since some implementations may not have that level of
     // accuracy.
     let start_time = Utc::now().with_nanosecond(0).unwrap();
-    trans.create_edge(key).unwrap();
+    trans.create_edge(&key).unwrap();
     let end_time = Utc::now();
 
     let e = trans
-        .get_edges(EdgeQuery::Edges {
+        .get_edges(&EdgeQuery::Edges {
             keys: vec![EdgeKey::new(outbound_id, edge_t.clone(), inbound_id)],
         })
         .unwrap();
@@ -47,18 +47,18 @@ where
     let trans = datastore.transaction().unwrap();
 
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
-    let outbound_id = trans.create_vertex(vertex_t.clone()).unwrap();
-    let inbound_id = trans.create_vertex(vertex_t).unwrap();
+    let outbound_id = trans.create_vertex(&vertex_t).unwrap();
+    let inbound_id = trans.create_vertex(&vertex_t).unwrap();
     let edge_t = models::Type::new("test_edge_type".to_string()).unwrap();
 
     let e = trans
-        .get_edges(EdgeQuery::Edges {
+        .get_edges(&EdgeQuery::Edges {
             keys: vec![EdgeKey::new(outbound_id, edge_t.clone(), Uuid::default())],
         })
         .unwrap();
     assert_eq!(e.len(), 0);
     let e = trans
-        .get_edges(EdgeQuery::Edges {
+        .get_edges(&EdgeQuery::Edges {
             keys: vec![EdgeKey::new(Uuid::default(), edge_t, inbound_id)],
         })
         .unwrap();
@@ -72,15 +72,15 @@ where
 {
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
     let trans = datastore.transaction().unwrap();
-    let outbound_id = trans.create_vertex(vertex_t.clone()).unwrap();
+    let outbound_id = trans.create_vertex(&vertex_t).unwrap();
     let edge_t = models::Type::new("test_edge_type".to_string()).unwrap();
-    let inbound_id = trans.create_vertex(vertex_t.clone()).unwrap();
+    let inbound_id = trans.create_vertex(&vertex_t).unwrap();
 
     // Set the edge and check
     let key = models::EdgeKey::new(outbound_id, edge_t.clone(), inbound_id);
-    trans.create_edge(key.clone()).unwrap();
+    trans.create_edge(&key).unwrap();
     let e = trans
-        .get_edges(EdgeQuery::Edges {
+        .get_edges(&EdgeQuery::Edges {
             keys: vec![key.clone()],
         })
         .unwrap();
@@ -89,11 +89,11 @@ where
 
     // `create_edge` should support the ability of updating an existing edge
     // - test for that
-    trans.create_edge(key.clone()).unwrap();
+    trans.create_edge(&key).unwrap();
 
     // First check that getting a single edge will still...get a single edge
     let e = trans
-        .get_edges(EdgeQuery::Edges {
+        .get_edges(&EdgeQuery::Edges {
             keys: vec![key.clone()],
         })
         .unwrap();
@@ -104,7 +104,7 @@ where
     // single edge
     let e = trans
         .get_edges(
-            VertexQuery::Vertices {
+            &VertexQuery::Vertices {
                 ids: vec![outbound_id],
             }.outbound_edges(None, None, None, 10),
         )
@@ -120,10 +120,10 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
-    let outbound_id = trans.create_vertex(vertex_t.clone()).unwrap();
+    let outbound_id = trans.create_vertex(&vertex_t).unwrap();
     let edge_t = models::Type::new("test_edge_type".to_string()).unwrap();
     let key = models::EdgeKey::new(outbound_id, edge_t.clone(), Uuid::default());
-    let result = trans.create_edge(key);
+    let result = trans.create_edge(&key);
     assert_eq!(result.unwrap(), false);
 }
 
@@ -134,19 +134,19 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_edge_type".to_string()).unwrap();
-    let outbound_id = trans.create_vertex(vertex_t.clone()).unwrap();
-    let inbound_id = trans.create_vertex(vertex_t).unwrap();
+    let outbound_id = trans.create_vertex(&vertex_t).unwrap();
+    let inbound_id = trans.create_vertex(&vertex_t).unwrap();
 
     let edge_t = models::Type::new("test_edge_type".to_string()).unwrap();
     let key = models::EdgeKey::new(outbound_id, edge_t.clone(), inbound_id);
-    trans.create_edge(key.clone()).unwrap();
+    trans.create_edge(&key).unwrap();
     trans
-        .delete_edges(EdgeQuery::Edges {
+        .delete_edges(&EdgeQuery::Edges {
             keys: vec![key.clone()],
         })
         .unwrap();
     let e = trans
-        .get_edges(EdgeQuery::Edges { keys: vec![key] })
+        .get_edges(&EdgeQuery::Edges { keys: vec![key] })
         .unwrap();
     assert_eq!(e.len(), 0);
 }
@@ -158,10 +158,10 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_edge_type".to_string()).unwrap();
-    let outbound_id = trans.create_vertex(vertex_t).unwrap();
+    let outbound_id = trans.create_vertex(&vertex_t).unwrap();
     let edge_t = models::Type::new("test_edge_type".to_string()).unwrap();
     trans
-        .delete_edges(EdgeQuery::Edges {
+        .delete_edges(&EdgeQuery::Edges {
             keys: vec![EdgeKey::new(outbound_id, edge_t, Uuid::default())],
         })
         .unwrap();
@@ -176,7 +176,7 @@ where
     let trans = datastore.transaction().unwrap();
     let t = models::Type::new("test_edge_type".to_string()).unwrap();
     let count = trans
-        .get_edge_count(outbound_id, Some(t), EdgeDirection::Outbound)
+        .get_edge_count(outbound_id, Some(&t), EdgeDirection::Outbound)
         .unwrap();
     assert_eq!(count, 5);
 }
@@ -202,7 +202,7 @@ where
     let trans = datastore.transaction().unwrap();
     let t = models::Type::new("test_edge_type".to_string()).unwrap();
     let count = trans
-        .get_edge_count(Uuid::default(), Some(t), EdgeDirection::Outbound)
+        .get_edge_count(Uuid::default(), Some(&t), EdgeDirection::Outbound)
         .unwrap();
     assert_eq!(count, 0);
 }
@@ -231,7 +231,7 @@ where
     let q = VertexQuery::Vertices {
         ids: vec![outbound_id],
     }.outbound_edges(Some(t), Some(end_time), Some(start_time), 10);
-    let range = trans.get_edges(q).unwrap();
+    let range = trans.get_edges(&q).unwrap();
     check_edge_range(&range, outbound_id, 5);
 }
 
@@ -245,7 +245,7 @@ where
     let q = VertexQuery::Vertices {
         ids: vec![outbound_id],
     }.outbound_edges(None, Some(end_time), Some(start_time), 10);
-    let range = trans.get_edges(q).unwrap();
+    let range = trans.get_edges(&q).unwrap();
     check_edge_range(&range, outbound_id, 5);
 }
 
@@ -260,7 +260,7 @@ where
     let q = VertexQuery::Vertices {
         ids: vec![outbound_id],
     }.outbound_edges(Some(t), Some(end_time), Some(start_time), 10);
-    let range = trans.get_edges(q).unwrap();
+    let range = trans.get_edges(&q).unwrap();
     check_edge_range(&range, outbound_id, 0);
 }
 
@@ -275,7 +275,7 @@ where
     let q = VertexQuery::Vertices {
         ids: vec![outbound_id],
     }.outbound_edges(Some(t), None, Some(start_time), 10);
-    let range = trans.get_edges(q).unwrap();
+    let range = trans.get_edges(&q).unwrap();
     check_edge_range(&range, outbound_id, 10);
 }
 
@@ -290,7 +290,7 @@ where
     let q = VertexQuery::Vertices {
         ids: vec![outbound_id],
     }.outbound_edges(Some(t), Some(end_time), None, 10);
-    let range = trans.get_edges(q).unwrap();
+    let range = trans.get_edges(&q).unwrap();
     check_edge_range(&range, outbound_id, 10);
 }
 
@@ -305,7 +305,7 @@ where
     let q = VertexQuery::Vertices {
         ids: vec![outbound_id],
     }.outbound_edges(Some(t), None, None, 100);
-    let range = trans.get_edges(q).unwrap();
+    let range = trans.get_edges(&q).unwrap();
     check_edge_range(&range, outbound_id, 15);
 }
 
@@ -320,7 +320,7 @@ where
     let q = VertexQuery::Vertices {
         ids: vec![outbound_id],
     }.outbound_edges(Some(t), Some(start_time), Some(end_time), 10);
-    let range = trans.get_edges(q).unwrap();
+    let range = trans.get_edges(&q).unwrap();
     check_edge_range(&range, outbound_id, 0);
 }
 
@@ -341,7 +341,7 @@ where
             EdgeKey::new(outbound_id, t.clone(), inbound_ids[4]),
         ],
     };
-    let range = trans.get_edges(q).unwrap();
+    let range = trans.get_edges(&q).unwrap();
     check_edge_range(&range, outbound_id, 5);
 }
 
@@ -353,7 +353,7 @@ where
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
 
-    let inserted_id_1 = trans.create_vertex(vertex_t.clone()).unwrap();
+    let inserted_id_1 = trans.create_vertex(&vertex_t).unwrap();
     let inserted_id_2 = create_edge_from::<D, T>(&trans, inserted_id_1);
 
     // This query should get `inserted_id_2`
@@ -365,7 +365,7 @@ where
         None,
         1,
     );
-    let range = trans.get_edges(query_1.clone()).unwrap();
+    let range = trans.get_edges(&query_1).unwrap();
     assert_eq!(range.len(), 1);
     assert_eq!(
         range[0].key,
@@ -383,7 +383,7 @@ where
         None,
         1,
     );
-    let range = trans.get_edges(query_2).unwrap();
+    let range = trans.get_edges(&query_2).unwrap();
     assert_eq!(range.len(), 1);
     assert_eq!(
         range[0].key,

--- a/lib/src/tests/edge.rs
+++ b/lib/src/tests/edge.rs
@@ -103,11 +103,9 @@ where
     // REGRESSION: Second check that getting an edge range will only fetch a
     // single edge
     let e = trans
-        .get_edges(
-            &VertexQuery::Vertices {
-                ids: vec![outbound_id],
-            }.outbound_edges(None, None, None, 10),
-        )
+        .get_edges(&VertexQuery::Vertices {
+            ids: vec![outbound_id],
+        }.outbound_edges(None, None, None, 10))
         .unwrap();
     assert_eq!(e.len(), 1);
     assert_eq!(key, e[0].key);

--- a/lib/src/tests/metadata.rs
+++ b/lib/src/tests/metadata.rs
@@ -12,29 +12,29 @@ where
     let trans = datastore.transaction().unwrap();
 
     // Check to make sure there's no initial value
-    let result = trans.get_global_metadata(name.clone());
+    let result = trans.get_global_metadata(&name);
     assert_eq!(result.unwrap(), None);
 
     // Set and get the value as true
     trans
-        .set_global_metadata(name.clone(), JsonValue::Bool(true))
+        .set_global_metadata(&name, JsonValue::Bool(true))
         .unwrap();
 
-    let result = trans.get_global_metadata(name.clone());
+    let result = trans.get_global_metadata(&name);
     assert_eq!(result.unwrap(), Some(JsonValue::Bool(true)));
 
     // Set and get the value as false
     trans
-        .set_global_metadata(name.clone(), JsonValue::Bool(false))
+        .set_global_metadata(&name, JsonValue::Bool(false))
         .unwrap();
 
-    let result = trans.get_global_metadata(name.clone());
+    let result = trans.get_global_metadata(&name);
     assert_eq!(result.unwrap(), Some(JsonValue::Bool(false)));
 
     // Delete & check that it's deleted
-    trans.delete_global_metadata(name.clone()).unwrap();
+    trans.delete_global_metadata(&name).unwrap();
 
-    let result = trans.get_global_metadata(name.clone());
+    let result = trans.get_global_metadata(&name);
     assert_eq!(result.unwrap(), None);
 }
 
@@ -45,39 +45,39 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let t = Type::new("test_edge_type".to_string()).unwrap();
-    let owner_id = trans.create_vertex(t).unwrap();
+    let owner_id = trans.create_vertex(&t).unwrap();
     let name = format!("vertex-metadata-{}", generate_random_secret(8));
     let q = VertexQuery::Vertices {
         ids: vec![owner_id],
     };
 
     // Check to make sure there's no initial value
-    let result = trans.get_vertex_metadata(q.clone(), name.clone()).unwrap();
+    let result = trans.get_vertex_metadata(&q, &name).unwrap();
     assert_eq!(result.len(), 0);
 
     // Set and get the value as true
     trans
-        .set_vertex_metadata(q.clone(), name.clone(), JsonValue::Bool(true))
+        .set_vertex_metadata(&q, &name, JsonValue::Bool(true))
         .unwrap();
-    let result = trans.get_vertex_metadata(q.clone(), name.clone()).unwrap();
+    let result = trans.get_vertex_metadata(&q, &name).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].id, owner_id);
     assert_eq!(result[0].value, JsonValue::Bool(true));
 
     // Set and get the value as false
     trans
-        .set_vertex_metadata(q.clone(), name.clone(), JsonValue::Bool(false))
+        .set_vertex_metadata(&q, &name, JsonValue::Bool(false))
         .unwrap();
-    let result = trans.get_vertex_metadata(q.clone(), name.clone()).unwrap();
+    let result = trans.get_vertex_metadata(&q, &name).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].id, owner_id);
     assert_eq!(result[0].value, JsonValue::Bool(false));
 
     // Delete & check that it's deleted
     trans
-        .delete_vertex_metadata(q.clone(), name.clone())
+        .delete_vertex_metadata(&q, &name)
         .unwrap();
-    let result = trans.get_vertex_metadata(q, name.clone()).unwrap();
+    let result = trans.get_vertex_metadata(&q, &name).unwrap();
     assert_eq!(result.len(), 0);
 }
 
@@ -91,9 +91,9 @@ where
         ids: vec![Uuid::default()],
     };
     trans
-        .set_vertex_metadata(q.clone(), "foo".to_string(), JsonValue::Null)
+        .set_vertex_metadata(&q, "foo", JsonValue::Null)
         .unwrap();
-    let result = trans.get_vertex_metadata(q, "foo".to_string()).unwrap();
+    let result = trans.get_vertex_metadata(&q, "foo").unwrap();
     assert_eq!(result.len(), 0);
 }
 
@@ -106,15 +106,15 @@ where
     let q = VertexQuery::Vertices {
         ids: vec![Uuid::default()],
     };
-    trans.delete_vertex_metadata(q, "foo".to_string()).unwrap();
+    trans.delete_vertex_metadata(&q, "foo").unwrap();
 
     let vertex_id = trans
-        .create_vertex(Type::new("foo".to_string()).unwrap())
+        .create_vertex(&Type::new("foo".to_string()).unwrap())
         .unwrap();
     let q = VertexQuery::Vertices {
         ids: vec![vertex_id],
     };
-    trans.delete_vertex_metadata(q, "foo".to_string()).unwrap();
+    trans.delete_vertex_metadata(&q, "foo").unwrap();
 }
 
 pub fn should_handle_edge_metadata<D, T>(datastore: &mut D)
@@ -124,8 +124,8 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = Type::new("test_edge_type".to_string()).unwrap();
-    let outbound_id = trans.create_vertex(vertex_t.clone()).unwrap();
-    let inbound_id = trans.create_vertex(vertex_t).unwrap();
+    let outbound_id = trans.create_vertex(&vertex_t).unwrap();
+    let inbound_id = trans.create_vertex(&vertex_t).unwrap();
     let edge_t = Type::new("test_edge_type".to_string()).unwrap();
     let key = EdgeKey::new(outbound_id, edge_t.clone(), inbound_id);
     let q = EdgeQuery::Edges {
@@ -133,33 +133,33 @@ where
     };
     let name = format!("edge-metadata-{}", generate_random_secret(8));
 
-    trans.create_edge(key.clone()).unwrap();
+    trans.create_edge(&key).unwrap();
 
     // Check to make sure there's no initial value
-    let result = trans.get_edge_metadata(q.clone(), name.clone()).unwrap();
+    let result = trans.get_edge_metadata(&q, &name).unwrap();
     assert_eq!(result.len(), 0);
 
     // Set and get the value as true
     trans
-        .set_edge_metadata(q.clone(), name.clone(), JsonValue::Bool(true))
+        .set_edge_metadata(&q, &name, JsonValue::Bool(true))
         .unwrap();
-    let result = trans.get_edge_metadata(q.clone(), name.clone()).unwrap();
+    let result = trans.get_edge_metadata(&q, &name).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].key, key);
     assert_eq!(result[0].value, JsonValue::Bool(true));
 
     // Set and get the value as false
     trans
-        .set_edge_metadata(q.clone(), name.clone(), JsonValue::Bool(false))
+        .set_edge_metadata(&q, &name, JsonValue::Bool(false))
         .unwrap();
-    let result = trans.get_edge_metadata(q.clone(), name.clone()).unwrap();
+    let result = trans.get_edge_metadata(&q, &name).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].key, key);
     assert_eq!(result[0].value, JsonValue::Bool(false));
 
     // Delete & check that it's deleted
-    trans.delete_edge_metadata(q.clone(), name.clone()).unwrap();
-    let result = trans.get_edge_metadata(q, name.clone()).unwrap();
+    trans.delete_edge_metadata(&q, &name).unwrap();
+    let result = trans.get_edge_metadata(&q, &name).unwrap();
     assert_eq!(result.len(), 0);
 }
 
@@ -179,9 +179,9 @@ where
         ],
     };
     trans
-        .set_edge_metadata(q.clone(), "bar".to_string(), JsonValue::Null)
+        .set_edge_metadata(&q, "bar", JsonValue::Null)
         .unwrap();
-    let result = trans.get_edge_metadata(q, "bar".to_string()).unwrap();
+    let result = trans.get_edge_metadata(&q, "bar").unwrap();
     assert_eq!(result.len(), 0);
 }
 
@@ -200,21 +200,21 @@ where
             ),
         ],
     };
-    trans.delete_edge_metadata(q, "bar".to_string()).unwrap();
+    trans.delete_edge_metadata(&q, "bar").unwrap();
 
     let outbound_id = trans
-        .create_vertex(Type::new("foo".to_string()).unwrap())
+        .create_vertex(&Type::new("foo".to_string()).unwrap())
         .unwrap();
     let inbound_id = trans
-        .create_vertex(Type::new("bar".to_string()).unwrap())
+        .create_vertex(&Type::new("bar".to_string()).unwrap())
         .unwrap();
     let key = EdgeKey::new(
         outbound_id,
         Type::new("baz".to_string()).unwrap(),
         inbound_id,
     );
-    trans.create_edge(key.clone()).unwrap();
+    trans.create_edge(&key).unwrap();
     trans
-        .delete_edge_metadata(EdgeQuery::Edges { keys: vec![key] }, "bleh".to_string())
+        .delete_edge_metadata(&EdgeQuery::Edges { keys: vec![key] }, "bleh")
         .unwrap();
 }

--- a/lib/src/tests/metadata.rs
+++ b/lib/src/tests/metadata.rs
@@ -74,9 +74,7 @@ where
     assert_eq!(result[0].value, JsonValue::Bool(false));
 
     // Delete & check that it's deleted
-    trans
-        .delete_vertex_metadata(&q, &name)
-        .unwrap();
+    trans.delete_vertex_metadata(&q, &name).unwrap();
     let result = trans.get_vertex_metadata(&q, &name).unwrap();
     assert_eq!(result.len(), 0);
 }

--- a/lib/src/tests/metadata.rs
+++ b/lib/src/tests/metadata.rs
@@ -17,7 +17,7 @@ where
 
     // Set and get the value as true
     trans
-        .set_global_metadata(&name, JsonValue::Bool(true))
+        .set_global_metadata(&name, &JsonValue::Bool(true))
         .unwrap();
 
     let result = trans.get_global_metadata(&name);
@@ -25,7 +25,7 @@ where
 
     // Set and get the value as false
     trans
-        .set_global_metadata(&name, JsonValue::Bool(false))
+        .set_global_metadata(&name, &JsonValue::Bool(false))
         .unwrap();
 
     let result = trans.get_global_metadata(&name);
@@ -57,7 +57,7 @@ where
 
     // Set and get the value as true
     trans
-        .set_vertex_metadata(&q, &name, JsonValue::Bool(true))
+        .set_vertex_metadata(&q, &name, &JsonValue::Bool(true))
         .unwrap();
     let result = trans.get_vertex_metadata(&q, &name).unwrap();
     assert_eq!(result.len(), 1);
@@ -66,7 +66,7 @@ where
 
     // Set and get the value as false
     trans
-        .set_vertex_metadata(&q, &name, JsonValue::Bool(false))
+        .set_vertex_metadata(&q, &name, &JsonValue::Bool(false))
         .unwrap();
     let result = trans.get_vertex_metadata(&q, &name).unwrap();
     assert_eq!(result.len(), 1);
@@ -91,7 +91,7 @@ where
         ids: vec![Uuid::default()],
     };
     trans
-        .set_vertex_metadata(&q, "foo", JsonValue::Null)
+        .set_vertex_metadata(&q, "foo", &JsonValue::Null)
         .unwrap();
     let result = trans.get_vertex_metadata(&q, "foo").unwrap();
     assert_eq!(result.len(), 0);
@@ -141,7 +141,7 @@ where
 
     // Set and get the value as true
     trans
-        .set_edge_metadata(&q, &name, JsonValue::Bool(true))
+        .set_edge_metadata(&q, &name, &JsonValue::Bool(true))
         .unwrap();
     let result = trans.get_edge_metadata(&q, &name).unwrap();
     assert_eq!(result.len(), 1);
@@ -150,7 +150,7 @@ where
 
     // Set and get the value as false
     trans
-        .set_edge_metadata(&q, &name, JsonValue::Bool(false))
+        .set_edge_metadata(&q, &name, &JsonValue::Bool(false))
         .unwrap();
     let result = trans.get_edge_metadata(&q, &name).unwrap();
     assert_eq!(result.len(), 1);
@@ -179,7 +179,7 @@ where
         ],
     };
     trans
-        .set_edge_metadata(&q, "bar", JsonValue::Null)
+        .set_edge_metadata(&q, "bar", &JsonValue::Null)
         .unwrap();
     let result = trans.get_edge_metadata(&q, "bar").unwrap();
     assert_eq!(result.len(), 0);

--- a/lib/src/tests/util.rs
+++ b/lib/src/tests/util.rs
@@ -10,10 +10,10 @@ where
     T: Transaction,
 {
     let inbound_vertex_t = models::Type::new("test_inbound_vertex_type".to_string()).unwrap();
-    let inbound_id = trans.create_vertex(inbound_vertex_t).unwrap();
+    let inbound_id = trans.create_vertex(&inbound_vertex_t).unwrap();
     let edge_t = models::Type::new("test_edge_type".to_string()).unwrap();
     let key = models::EdgeKey::new(outbound_id, edge_t, inbound_id);
-    trans.create_edge(key).unwrap();
+    trans.create_edge(&key).unwrap();
     inbound_id
 }
 
@@ -24,7 +24,7 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let outbound_vertex_t = models::Type::new("test_outbound_vertex_type".to_string()).unwrap();
-    let outbound_id = trans.create_vertex(outbound_vertex_t).unwrap();
+    let outbound_id = trans.create_vertex(&outbound_vertex_t).unwrap();
     let inbound_ids: [Uuid; 5] = [
         create_edge_from::<D, T>(&trans, outbound_id),
         create_edge_from::<D, T>(&trans, outbound_id),
@@ -45,7 +45,7 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let outbound_vertex_t = models::Type::new("test_outbound_vertex_type".to_string()).unwrap();
-    let outbound_id = trans.create_vertex(outbound_vertex_t).unwrap();
+    let outbound_id = trans.create_vertex(&outbound_vertex_t).unwrap();
 
     create_edge_from::<D, T>(&trans, outbound_id);
     create_edge_from::<D, T>(&trans, outbound_id);

--- a/lib/src/tests/vertex.rs
+++ b/lib/src/tests/vertex.rs
@@ -14,16 +14,16 @@ where
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
 
     let mut inserted_ids = vec![
-        trans.create_vertex(vertex_t.clone()).unwrap(),
-        trans.create_vertex(vertex_t.clone()).unwrap(),
-        trans.create_vertex(vertex_t.clone()).unwrap(),
-        trans.create_vertex(vertex_t.clone()).unwrap(),
-        trans.create_vertex(vertex_t.clone()).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
     ];
 
     inserted_ids.sort();
     let range = trans
-        .get_vertices(VertexQuery::All {
+        .get_vertices(&VertexQuery::All {
             start_id: None,
             limit: u32::MAX,
         })
@@ -35,7 +35,7 @@ where
 
     for vertex in &range {
         if let Ok(index) = inserted_ids.binary_search(&vertex.id) {
-            assert_eq!(vertex.t, vertex_t.clone());
+            assert_eq!(vertex.t, vertex_t);
             inserted_ids.remove(index);
         }
 
@@ -53,16 +53,16 @@ where
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
 
     let mut inserted_ids = vec![
-        trans.create_vertex(vertex_t.clone()).unwrap(),
-        trans.create_vertex(vertex_t.clone()).unwrap(),
-        trans.create_vertex(vertex_t.clone()).unwrap(),
-        trans.create_vertex(vertex_t.clone()).unwrap(),
-        trans.create_vertex(vertex_t.clone()).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
     ];
 
     inserted_ids.sort();
     let range = trans
-        .get_vertices(VertexQuery::All {
+        .get_vertices(&VertexQuery::All {
             start_id: None,
             limit: 0,
         })
@@ -79,16 +79,16 @@ where
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
 
     let mut inserted_ids = vec![
-        trans.create_vertex(vertex_t.clone()).unwrap(),
-        trans.create_vertex(vertex_t.clone()).unwrap(),
-        trans.create_vertex(vertex_t.clone()).unwrap(),
-        trans.create_vertex(vertex_t.clone()).unwrap(),
-        trans.create_vertex(vertex_t.clone()).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
     ];
 
     inserted_ids.sort();
     let range = trans
-        .get_vertices(VertexQuery::All {
+        .get_vertices(&VertexQuery::All {
             start_id: Some(Uuid::parse_str("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").unwrap()),
             limit: u32::MAX,
         })
@@ -103,9 +103,9 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
-    let inserted_id = trans.create_vertex(vertex_t.clone()).unwrap();
+    let inserted_id = trans.create_vertex(&vertex_t).unwrap();
     let range = trans
-        .get_vertices(VertexQuery::Vertices {
+        .get_vertices(&VertexQuery::Vertices {
             ids: vec![inserted_id],
         })
         .unwrap();
@@ -121,9 +121,9 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
-    trans.create_vertex(vertex_t.clone()).unwrap();
+    trans.create_vertex(&vertex_t).unwrap();
     let range = trans
-        .get_vertices(VertexQuery::Vertices {
+        .get_vertices(&VertexQuery::Vertices {
             ids: vec![Uuid::default()],
         })
         .unwrap();
@@ -138,14 +138,14 @@ where
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
     let mut inserted_ids = vec![
-        trans.create_vertex(vertex_t.clone()).unwrap(),
-        trans.create_vertex(vertex_t.clone()).unwrap(),
-        trans.create_vertex(vertex_t.clone()).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
+        trans.create_vertex(&vertex_t).unwrap(),
     ];
 
     inserted_ids.sort();
     let range = trans
-        .get_vertices(VertexQuery::Vertices {
+        .get_vertices(&VertexQuery::Vertices {
             ids: vec![
                 inserted_ids[0],
                 inserted_ids[1],
@@ -161,7 +161,7 @@ where
 
     for vertex in &range {
         if let Ok(index) = inserted_ids.binary_search(&vertex.id) {
-            assert_eq!(vertex.t, vertex_t.clone());
+            assert_eq!(vertex.t, vertex_t);
             inserted_ids.remove(index);
         }
 
@@ -178,7 +178,7 @@ where
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
 
-    let inserted_id_1 = trans.create_vertex(vertex_t.clone()).unwrap();
+    let inserted_id_1 = trans.create_vertex(&vertex_t).unwrap();
     let inserted_id_2 = create_edge_from::<D, T>(&trans, inserted_id_1);
 
     // This query should get `inserted_id_2`
@@ -191,7 +191,7 @@ where
         1,
     )
         .inbound_vertices(1);
-    let range = trans.get_vertices(query_1.clone()).unwrap();
+    let range = trans.get_vertices(&query_1).unwrap();
     assert_eq!(range.len(), 1);
     assert_eq!(range[0].id, inserted_id_2);
 
@@ -204,7 +204,7 @@ where
             1,
         )
         .outbound_vertices(1);
-    let range = trans.get_vertices(query_2).unwrap();
+    let range = trans.get_vertices(&query_2).unwrap();
     assert_eq!(range.len(), 1);
     assert_eq!(range[0].id, inserted_id_1);
 }
@@ -219,12 +219,12 @@ where
     let q = VertexQuery::Vertices {
         ids: vec![outbound_id],
     };
-    trans.delete_vertices(q.clone()).unwrap();
-    let v = trans.get_vertices(q.clone()).unwrap();
+    trans.delete_vertices(&q).unwrap();
+    let v = trans.get_vertices(&q).unwrap();
     assert_eq!(v.len(), 0);
     let t = models::Type::new("test_edge_type".to_string()).unwrap();
     let count = trans
-        .get_edge_count(outbound_id, Some(t), models::EdgeDirection::Outbound)
+        .get_edge_count(outbound_id, Some(&t), models::EdgeDirection::Outbound)
         .unwrap();
     assert_eq!(count, 0);
 }
@@ -236,7 +236,7 @@ where
 {
     let trans = datastore.transaction().unwrap();
     trans
-        .delete_vertices(VertexQuery::Vertices {
+        .delete_vertices(&VertexQuery::Vertices {
             ids: vec![Uuid::default()],
         })
         .unwrap();
@@ -249,7 +249,7 @@ where
 {
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
     let trans = datastore.transaction().unwrap();
-    trans.create_vertex(vertex_t.clone()).unwrap();
+    trans.create_vertex(&vertex_t).unwrap();
     let count = trans.get_vertex_count().unwrap();
     assert!(count >= 1);
 }

--- a/lib/src/traits.rs
+++ b/lib/src/traits.rs
@@ -29,19 +29,19 @@ pub trait Transaction {
     ///
     /// # Arguments
     /// * `t` - The type of the vertex.
-    fn create_vertex(&self, t: models::Type) -> Result<Uuid>;
+    fn create_vertex(&self, t: &models::Type) -> Result<Uuid>;
 
     /// Gets a range of vertices specified by a query.
     ///
     /// # Arguments
     /// * `q` - The query to run.
-    fn get_vertices(&self, q: models::VertexQuery) -> Result<Vec<models::Vertex>>;
+    fn get_vertices(&self, q: &models::VertexQuery) -> Result<Vec<models::Vertex>>;
 
     /// Deletes existing vertices specified by a query.
     ///
     /// # Arguments
     /// * `q` - The query to run.
-    fn delete_vertices(&self, q: models::VertexQuery) -> Result<()>;
+    fn delete_vertices(&self, q: &models::VertexQuery) -> Result<()>;
 
     /// Gets the number of vertices in the datastore..
     fn get_vertex_count(&self) -> Result<u64>;
@@ -53,19 +53,19 @@ pub trait Transaction {
     ///
     /// # Arguments
     /// * `key`: The edge to create.
-    fn create_edge(&self, key: models::EdgeKey) -> Result<bool>;
+    fn create_edge(&self, key: &models::EdgeKey) -> Result<bool>;
 
     /// Gets a range of edges specified by a query.
     ///
     /// # Arguments
     /// * `q` - The query to run.
-    fn get_edges(&self, q: models::EdgeQuery) -> Result<Vec<models::Edge>>;
+    fn get_edges(&self, q: &models::EdgeQuery) -> Result<Vec<models::Edge>>;
 
     /// Deletes a set of edges specified by a query.
     ///
     /// # Arguments
     /// * `q` - The query to run.
-    fn delete_edges(&self, q: models::EdgeQuery) -> Result<()>;
+    fn delete_edges(&self, q: &models::EdgeQuery) -> Result<()>;
 
     /// Gets the number of edges associated with a vertex.
     ///
@@ -76,7 +76,7 @@ pub trait Transaction {
     fn get_edge_count(
         &self,
         id: Uuid,
-        type_filter: Option<models::Type>,
+        type_filter: Option<&models::Type>,
         direction: models::EdgeDirection,
     ) -> Result<u64>;
 
@@ -87,20 +87,20 @@ pub trait Transaction {
     ///
     /// # Errors
     /// Returns `Error::MetadataNotFound` if the metadata does not exist.
-    fn get_global_metadata(&self, name: String) -> Result<Option<JsonValue>>;
+    fn get_global_metadata(&self, name: &str) -> Result<Option<JsonValue>>;
 
     /// Sets a global metadata value.
     ///
     /// # Arguments
     /// * `name` - The metadata name.
     /// * `value` - The metadata value.
-    fn set_global_metadata(&self, name: String, value: JsonValue) -> Result<()>;
+    fn set_global_metadata(&self, name: &str, value: JsonValue) -> Result<()>;
 
     /// Deletes a global metadata value.
     ///
     /// # Arguments
     /// * `name` - The metadata name.
-    fn delete_global_metadata(&self, name: String) -> Result<()>;
+    fn delete_global_metadata(&self, name: &str) -> Result<()>;
 
     /// Gets a vertex metadata value.
     ///
@@ -109,8 +109,8 @@ pub trait Transaction {
     /// * `name` - The metadata name.
     fn get_vertex_metadata(
         &self,
-        q: models::VertexQuery,
-        name: String,
+        q: &models::VertexQuery,
+        name: &str,
     ) -> Result<Vec<models::VertexMetadata>>;
 
     /// Sets a vertex metadata value.
@@ -121,8 +121,8 @@ pub trait Transaction {
     /// * `value` - The metadata value.
     fn set_vertex_metadata(
         &self,
-        q: models::VertexQuery,
-        name: String,
+        q: &models::VertexQuery,
+        name: &str,
         value: JsonValue,
     ) -> Result<()>;
 
@@ -131,7 +131,7 @@ pub trait Transaction {
     /// # Arguments
     /// * `q` - The query to run.
     /// * `name` - The metadata name.
-    fn delete_vertex_metadata(&self, q: models::VertexQuery, name: String) -> Result<()>;
+    fn delete_vertex_metadata(&self, q: &models::VertexQuery, name: &str) -> Result<()>;
 
     /// Gets an edge metadata value.
     ///
@@ -140,8 +140,8 @@ pub trait Transaction {
     /// * `name` - The metadata name.
     fn get_edge_metadata(
         &self,
-        q: models::EdgeQuery,
-        name: String,
+        q: &models::EdgeQuery,
+        name: &str,
     ) -> Result<Vec<models::EdgeMetadata>>;
 
     /// Sets an edge metadata value.
@@ -150,7 +150,7 @@ pub trait Transaction {
     /// * `q` - The query to run.
     /// * `name` - The metadata name.
     /// * `value` - The metadata value.
-    fn set_edge_metadata(&self, q: models::EdgeQuery, name: String, value: JsonValue)
+    fn set_edge_metadata(&self, q: &models::EdgeQuery, name: &str, value: JsonValue)
         -> Result<()>;
 
     /// Deletes an edge metadata value.
@@ -158,5 +158,5 @@ pub trait Transaction {
     /// # Arguments
     /// * `q` - The query to run.
     /// * `name` - The metadata name.
-    fn delete_edge_metadata(&self, q: models::EdgeQuery, name: String) -> Result<()>;
+    fn delete_edge_metadata(&self, q: &models::EdgeQuery, name: &str) -> Result<()>;
 }

--- a/lib/src/traits.rs
+++ b/lib/src/traits.rs
@@ -94,7 +94,7 @@ pub trait Transaction {
     /// # Arguments
     /// * `name` - The metadata name.
     /// * `value` - The metadata value.
-    fn set_global_metadata(&self, name: &str, value: JsonValue) -> Result<()>;
+    fn set_global_metadata(&self, name: &str, value: &JsonValue) -> Result<()>;
 
     /// Deletes a global metadata value.
     ///
@@ -123,7 +123,7 @@ pub trait Transaction {
         &self,
         q: &models::VertexQuery,
         name: &str,
-        value: JsonValue,
+        value: &JsonValue,
     ) -> Result<()>;
 
     /// Deletes a vertex metadata value.
@@ -150,7 +150,7 @@ pub trait Transaction {
     /// * `q` - The query to run.
     /// * `name` - The metadata name.
     /// * `value` - The metadata value.
-    fn set_edge_metadata(&self, q: &models::EdgeQuery, name: &str, value: JsonValue)
+    fn set_edge_metadata(&self, q: &models::EdgeQuery, name: &str, value: &JsonValue)
         -> Result<()>;
 
     /// Deletes an edge metadata value.


### PR DESCRIPTION
This leads to better ergonomics when directly using transactions, and allows for better performance in some datastore implementations that do not need ownership of arguments.