### PR TITLE
Pass in a full vertex to `create_vertex`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Applications are configured via environment variables:
 * `INDRADB_SCRIPT_ROOT`: The directory housing the lua scripts. Defaults to `./scripts`.
 * `INDRADB_MAP_REDUCE_QUERY_LIMIT`: How many vertices to query at a time when executing mapreduce tasks. Higher values will consume more memory. Defaults to `10000`.
 * `MAP_REDUCE_WORKER_POOL_SIZE`: How many worker threads to spawn for mapreduce tasks. Defaults to the number of CPUs.
+* `INDRADB_SECURE_UUIDS`: Set to `true` to generate random UUID that are not trivial to guess. This likely decreases performance depending on the datastore used.
 
 ## Install from source
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Applications are configured via environment variables:
 * `INDRADB_SCRIPT_ROOT`: The directory housing the lua scripts. Defaults to `./scripts`.
 * `INDRADB_MAP_REDUCE_QUERY_LIMIT`: How many vertices to query at a time when executing mapreduce tasks. Higher values will consume more memory. Defaults to `10000`.
 * `MAP_REDUCE_WORKER_POOL_SIZE`: How many worker threads to spawn for mapreduce tasks. Defaults to the number of CPUs.
-* `INDRADB_SECURE_UUIDS`: Set to `true` to generate random UUID that are not trivial to guess. This likely decreases performance depending on the datastore used.
 
 ## Install from source
 

--- a/bin/src/common/datastore.rs
+++ b/bin/src/common/datastore.rs
@@ -61,7 +61,7 @@ impl Transaction for ProxyTransaction {
         proxy_transaction!(self, get_vertices, q)
     }
 
-    fn create_vertex(&self, v: &Vertex) -> Result<(), Error> {
+    fn create_vertex(&self, v: &Vertex) -> Result<bool, Error> {
         proxy_transaction!(self, create_vertex, v)
     }
 

--- a/bin/src/common/datastore.rs
+++ b/bin/src/common/datastore.rs
@@ -61,8 +61,8 @@ impl Transaction for ProxyTransaction {
         proxy_transaction!(self, get_vertices, q)
     }
 
-    fn create_vertex(&self, t: &Type) -> Result<Uuid, Error> {
-        proxy_transaction!(self, create_vertex, t)
+    fn create_vertex(&self, v: &Vertex) -> Result<(), Error> {
+        proxy_transaction!(self, create_vertex, v)
     }
 
     fn delete_vertices(&self, q: &VertexQuery) -> Result<(), Error> {
@@ -152,8 +152,6 @@ impl Transaction for ProxyTransaction {
 /// use.
 pub fn datastore() -> ProxyDatastore {
     let connection_string = env::var("DATABASE_URL").unwrap_or_else(|_| "memory://".to_string());
-    let secure_uuids =
-        env::var("INDRADB_SECURE_UUIDS").unwrap_or_else(|_| "false".to_string()) == "true";
 
     if connection_string.starts_with("rocksdb://") {
         let path = &connection_string[10..connection_string.len()];
@@ -165,7 +163,7 @@ pub fn datastore() -> ProxyDatastore {
              i32",
         );
 
-        let datastore = RocksdbDatastore::new(path, Some(max_open_files), secure_uuids)
+        let datastore = RocksdbDatastore::new(path, Some(max_open_files))
             .expect("Expected to be able to create the RocksDB datastore");
 
         ProxyDatastore::Rocksdb(datastore)
@@ -178,7 +176,7 @@ pub fn datastore() -> ProxyDatastore {
             Err(_) => None,
         };
 
-        let datastore = PostgresDatastore::new(pool_size, connection_string, secure_uuids)
+        let datastore = PostgresDatastore::new(pool_size, connection_string)
             .expect("Expected to be able to create the postgres datastore");
         ProxyDatastore::Postgres(datastore)
     } else if connection_string == "memory://" {

--- a/bin/src/server/http/endpoints.rs
+++ b/bin/src/server/http/endpoints.rs
@@ -1,6 +1,6 @@
 use iron::prelude::*;
 use iron::status;
-use indradb::{EdgeDirection, EdgeKey, EdgeQuery, Error, Transaction, Type, VertexQuery};
+use indradb::{EdgeDirection, EdgeKey, EdgeQuery, Error, Transaction, Type, Vertex, VertexQuery};
 use common::ProxyTransaction;
 use serde_json::value::Value as JsonValue;
 use serde_json;
@@ -120,8 +120,8 @@ fn create_vertex(
     trans: &ProxyTransaction,
     item: &serde_json::Map<String, JsonValue>,
 ) -> Result<JsonValue, IronError> {
-    let t = get_json_obj_value::<Type>(item, "type")?;
-    execute_item(trans.create_vertex(&t))
+    let v = get_json_obj_value::<Vertex>(item, "vertex")?;
+    execute_item(trans.create_vertex(&v))
 }
 
 fn get_vertices(

--- a/bin/src/server/http/endpoints.rs
+++ b/bin/src/server/http/endpoints.rs
@@ -117,7 +117,14 @@ pub fn transaction(req: &mut Request) -> IronResult<Response> {
 }
 
 fn create_vertex(trans: &ProxyTransaction, item: &serde_json::Map<String, JsonValue>) -> Result<JsonValue, IronError> {
-    let v = get_json_obj_value::<Vertex>(item, "vertex")?;
+    let t = get_optional_json_obj_value::<Type>(item, "type")?;
+
+    let v = if let Some(t) = t {
+        Vertex::new(t)
+    } else {
+        get_json_obj_value::<Vertex>(item, "vertex")?
+    };
+
     execute_item(trans.create_vertex(&v))
 }
 
@@ -155,7 +162,7 @@ fn delete_edges(trans: &ProxyTransaction, item: &serde_json::Map<String, JsonVal
 
 fn get_edge_count(trans: &ProxyTransaction, item: &serde_json::Map<String, JsonValue>) -> Result<JsonValue, IronError> {
     let id = get_json_obj_value::<Uuid>(item, "id")?;
-    let type_filter = get_json_obj_value::<Option<Type>>(item, "type_filter")?;
+    let type_filter = get_optional_json_obj_value::<Type>(item, "type_filter")?;
     let direction = get_json_obj_value::<EdgeDirection>(item, "direction")?;
     execute_item(trans.get_edge_count(id, type_filter.as_ref(), direction))
 }

--- a/bin/src/server/http/util.rs
+++ b/bin/src/server/http/util.rs
@@ -70,6 +70,27 @@ pub fn get_url_param<T: FromStr>(req: &Request, name: &str) -> Result<T, IronErr
     })
 }
 
+/// Gets an optional JSON object value.
+///
+/// # Errors
+/// Returns an `IronError` if the value has an unexpected type.
+pub fn get_optional_json_obj_value<T>(json: &serde_json::Map<String, JsonValue>, name: &str) -> Result<Option<T>, IronError>
+where
+    for<'a> T: Deserialize<'a>,
+{
+    if let Some(obj) = json.get(name) {
+        if obj.is_null() {
+            Ok(None)
+        } else {
+            let val = serde_json::from_value::<T>(obj.clone())
+                .map_err(|_| create_iron_error(status::BadRequest, format!("Invalid type for `{}`", name)))?;
+            Ok(Some(val))
+        }
+    } else {
+        Ok(None)
+    }
+}
+
 /// Gets a JSON object value.
 ///
 /// # Errors

--- a/bin/src/server/script/api.rs
+++ b/bin/src/server/script/api.rs
@@ -8,9 +8,10 @@ use serde_json::Value as JsonValue;
 
 pub fn create_vertex(
     trans: &ProxyTransaction,
-    t: converters::Type,
-) -> Result<converters::Uuid, Error> {
-    Ok(converters::Uuid::new(trans.create_vertex(&t.0)?))
+    v: converters::Vertex,
+) -> Result<(), Error> {
+    trans.create_vertex(&v.0)?;
+    Ok(())
 }
 
 pub fn get_vertices(
@@ -32,9 +33,8 @@ pub fn get_vertex_count(trans: &ProxyTransaction, _: ()) -> Result<u64, Error> {
     trans.get_vertex_count()
 }
 
-pub fn create_edge(trans: &ProxyTransaction, key: converters::EdgeKey) -> Result<(), Error> {
-    trans.create_edge(&key.0)?;
-    Ok(())
+pub fn create_edge(trans: &ProxyTransaction, key: converters::EdgeKey) -> Result<bool, Error> {
+    Ok(trans.create_edge(&key.0)?)
 }
 
 pub fn get_edges(

--- a/bin/src/server/script/context.rs
+++ b/bin/src/server/script/context.rs
@@ -2,7 +2,7 @@ use rlua::Table;
 use rlua::prelude::*;
 use serde_json::value::Value as JsonValue;
 use std::path::Path;
-use indradb::Datastore;
+use indradb::{Vertex, Datastore};
 use statics;
 use super::{converters, globals};
 
@@ -36,6 +36,15 @@ pub fn create(arg: JsonValue) -> Result<Lua, LuaError> {
                 Ok(converters::ProxyTransaction::new(trans))
             })?,
         )?;
+        g.set("vertex", l.create_function(|_, (t,): (converters::Type,)| {
+            let v = if *statics::SECURE_UUIDS {
+                Vertex::new_secure(t.0)
+            } else {
+                Vertex::new(t.0)
+            };
+
+            Ok(converters::Vertex::new(v))
+        })?)?;
     }
 
     let _: () = l.eval(globals::GLOBALS, Some("globals.lua"))?;

--- a/bin/src/server/script/context.rs
+++ b/bin/src/server/script/context.rs
@@ -37,12 +37,7 @@ pub fn create(arg: JsonValue) -> Result<Lua, LuaError> {
             })?,
         )?;
         g.set("vertex", l.create_function(|_, (t,): (converters::Type,)| {
-            let v = if *statics::SECURE_UUIDS {
-                Vertex::new_secure(t.0)
-            } else {
-                Vertex::new(t.0)
-            };
-
+            let v = Vertex::new(t.0);
             Ok(converters::Vertex::new(v))
         })?)?;
     }

--- a/bin/src/server/script/converters.rs
+++ b/bin/src/server/script/converters.rs
@@ -266,6 +266,15 @@ impl Vertex {
     }
 }
 
+impl<'lua> FromLua<'lua> for Vertex {
+    fn from_lua(value: Value<'lua>, l: &'lua Lua) -> LuaResult<Self> {
+        let table = Table::from_lua(value, l)?;
+        let id = Uuid::from_lua(table.get("id")?, l)?;
+        let t = Type::from_lua(table.get("type")?, l)?;
+        Ok(Vertex::new(ExternalVertex::with_id(id.0, t.0)))
+    }
+}
+
 impl<'lua> ToLua<'lua> for Vertex {
     fn to_lua(self, l: &'lua Lua) -> LuaResult<Value<'lua>> {
         let table = l.create_table()?;

--- a/bin/src/server/script/mapreduce/master.rs
+++ b/bin/src/server/script/mapreduce/master.rs
@@ -180,10 +180,8 @@ mod tests {
         );
 
         for _ in 0..insert_count {
-            engine.add_vertex(Vertex::new(
-                Uuid::new_v4(),
-                Type::new("foo".to_string()).unwrap(),
-            ));
+            let t = Type::new("foo".to_string()).unwrap();
+            engine.add_vertex(Vertex::new(t));
         }
 
         assert_eq!(engine.join().unwrap(), expected_result);

--- a/bin/src/server/script/mapreduce/master.rs
+++ b/bin/src/server/script/mapreduce/master.rs
@@ -153,7 +153,6 @@ mod tests {
     use std::fs::File;
     use std::io::prelude::*;
     use std::path::Path;
-    use uuid::Uuid;
 
     fn run(insert_count: u64, expected_finish_count: u64, expected_result: JsonValue) {
         let file_path_str = "test_scripts/mapreduce/count.lua";

--- a/bin/src/server/script/mapreduce/mod.rs
+++ b/bin/src/server/script/mapreduce/mod.rs
@@ -120,16 +120,15 @@ mod tests {
     use indradb::Type;
     use statics;
     use script;
-    use indradb::{Datastore, Transaction};
+    use indradb::{Vertex, Datastore, Transaction};
     use super::response_chan::Update;
     use serde_json::Value as JsonValue;
 
     /// Ensures there's at least one vertex to process
     fn add_seed() {
         let trans = statics::DATASTORE.transaction().unwrap();
-        trans
-            .create_vertex(&Type::new("foo".to_string()).unwrap())
-            .unwrap();
+        let vertex = Vertex::new(Type::new("foo".to_string()).unwrap());
+        trans.create_vertex(&vertex).unwrap();
     }
 
     fn run(file_path_str: &str, input: JsonValue) -> JsonValue {

--- a/bin/src/server/statics.rs
+++ b/bin/src/server/statics.rs
@@ -37,7 +37,4 @@ lazy_static! {
         },
         Err(_) => num_cpus::get() as u16
     };
-
-    /// Whether to use secure UUIDs
-    pub static ref SECURE_UUIDS: bool = env::var("INDRADB_SECURE_UUIDS").unwrap_or_else(|_| "false".to_string()) == "true";
 }

--- a/bin/src/server/statics.rs
+++ b/bin/src/server/statics.rs
@@ -37,4 +37,7 @@ lazy_static! {
         },
         Err(_) => num_cpus::get() as u16
     };
+
+    /// Whether to use secure UUIDs
+    pub static ref SECURE_UUIDS: bool = env::var("INDRADB_SECURE_UUIDS").unwrap_or_else(|_| "false".to_string()) == "true";
 }

--- a/bin/test_scripts/execute/commit_first.lua
+++ b/bin/test_scripts/execute/commit_first.lua
@@ -1,2 +1,4 @@
 local trans = transaction();
-return trans:create_vertex("foo");
+local v = vertex("foo");
+trans:create_vertex(v);
+return v

--- a/bin/test_scripts/execute/commit_second.lua
+++ b/bin/test_scripts/execute/commit_second.lua
@@ -1,4 +1,4 @@
 local trans = transaction();
-local vertices = trans:get_vertices(VertexQuery.vertices({arg}));
+local vertices = trans:get_vertices(VertexQuery.vertices({arg.id}));
 assert(#vertices == 1);
-assert(vertices[1].id == arg);
+assert(vertices[1].id == arg.id);

--- a/bin/test_scripts/execute/create_vertex.lua
+++ b/bin/test_scripts/execute/create_vertex.lua
@@ -1,5 +1,6 @@
 local trans = transaction();
-local id = trans:create_vertex("foo");
-local vertices = trans:get_vertices(VertexQuery.vertices({id}));
-assert(vertices[1].id == id);
+local v = vertex("foo");
+trans:create_vertex(v);
+local vertices = trans:get_vertices(VertexQuery.vertices({v.id}));
+assert(vertices[1].id == v.id);
 assert(vertices[1].type == "foo");

--- a/bin/test_scripts/execute/create_vertex_bad_type.lua
+++ b/bin/test_scripts/execute/create_vertex_bad_type.lua
@@ -9,4 +9,5 @@ end
 
 local status, err = pcall(test_create_vertex_bad_type);
 assert(status == false);
-assert(tostring(err) == "error converting Lua function to String (expected string or number)");
+print(tostring(err));
+assert(tostring(err) == "error converting Lua function to table");

--- a/bin/test_scripts/execute/delete_edges.lua
+++ b/bin/test_scripts/execute/delete_edges.lua
@@ -1,7 +1,9 @@
 local trans = transaction();
-local outbound_id = trans:create_vertex("foo");
-local inbound_id = trans:create_vertex("bar");
-local key = EdgeKey.new(outbound_id, "baz", inbound_id);
+local outbound = vertex("foo");
+trans:create_vertex(outbound);
+local inbound = vertex("foo");
+trans:create_vertex(inbound);
+local key = EdgeKey.new(outbound.id, "baz", inbound.id);
 trans:create_edge(key);
 trans:delete_edges(EdgeQuery.edges({key}));
 

--- a/bin/test_scripts/execute/delete_vertices.lua
+++ b/bin/test_scripts/execute/delete_vertices.lua
@@ -1,5 +1,6 @@
 local trans = transaction();
-local id = trans:create_vertex("foo");
-trans:delete_vertices(VertexQuery.vertices({id}));
-local vertices = trans:get_vertices(VertexQuery.vertices({id}));
+local v = vertex("foo");
+trans:create_vertex(v);
+trans:delete_vertices(VertexQuery.vertices({v.id}));
+local vertices = trans:get_vertices(VertexQuery.vertices({v.id}));
 assert(#vertices == 0);

--- a/bin/test_scripts/execute/edge_metadata.lua
+++ b/bin/test_scripts/execute/edge_metadata.lua
@@ -1,7 +1,9 @@
 local trans = transaction();
-local outbound_id = trans:create_vertex("foo");
-local inbound_id = trans:create_vertex("bar");
-local key = EdgeKey.new(outbound_id, "baz", inbound_id);
+local outbound = vertex("foo");
+trans:create_vertex(outbound);
+local inbound = vertex("foo");
+trans:create_vertex(inbound);
+local key = EdgeKey.new(outbound.id, "baz", inbound.id);
 trans:create_edge(key);
 
 local q = EdgeQuery.edges({key});
@@ -9,9 +11,9 @@ trans:set_edge_metadata(q, "script-test-edge", {foo={true, false}});
 local val = trans:get_edge_metadata(q, "script-test-edge");
 
 assert(#val == 1);
-assert(val[1].key.outbound_id == outbound_id);
+assert(val[1].key.outbound_id == outbound.id);
 assert(val[1].key.type == "baz");
-assert(val[1].key.inbound_id == inbound_id);
+assert(val[1].key.inbound_id == inbound.id);
 assert(val[1].value.foo[1] == true);
 assert(val[1].value.foo[2] == false);
 

--- a/bin/test_scripts/execute/get_edge_count.lua
+++ b/bin/test_scripts/execute/get_edge_count.lua
@@ -1,10 +1,12 @@
 local trans = transaction();
-local outbound_id = trans:create_vertex("foo");
-local inbound_id = trans:create_vertex("bar");
-trans:create_edge(EdgeKey.new(outbound_id, "baz", inbound_id));
+local outbound = vertex("foo");
+trans:create_vertex(outbound);
+local inbound = vertex("foo");
+trans:create_vertex(inbound);
+trans:create_edge(EdgeKey.new(outbound.id, "baz", inbound.id));
 
-local count = trans:get_edge_count(outbound_id, "baz", "outbound");
+local count = trans:get_edge_count(outbound.id, "baz", "outbound");
 assert(count == 1);
 
-local count = trans:get_edge_count(outbound_id, nil, "outbound");
+local count = trans:get_edge_count(outbound.id, nil, "outbound");
 assert(count == 1);

--- a/bin/test_scripts/execute/get_edges.lua
+++ b/bin/test_scripts/execute/get_edges.lua
@@ -1,16 +1,18 @@
 local trans = transaction();
-local outbound_id = trans:create_vertex("foo");
-local inbound_id = trans:create_vertex("bar");
-trans:create_edge(EdgeKey.new(outbound_id, "baz", inbound_id));
+local outbound = vertex("foo");
+trans:create_vertex(outbound);
+local inbound = vertex("foo");
+trans:create_vertex(inbound);
+trans:create_edge(EdgeKey.new(outbound.id, "baz", inbound.id));
 
-local edges = trans:get_edges(VertexQuery.vertices({outbound_id}):outbound_edges("baz", nil, nil, 10));
+local edges = trans:get_edges(VertexQuery.vertices({outbound.id}):outbound_edges("baz", nil, nil, 10));
 assert(#edges == 1);
-assert(edges[1].key.outbound_id == outbound_id);
+assert(edges[1].key.outbound_id == outbound.id);
 assert(edges[1].key.type == "baz");
-assert(edges[1].key.inbound_id == inbound_id);
+assert(edges[1].key.inbound_id == inbound.id);
 
-local edges = trans:get_edges(VertexQuery.vertices({outbound_id}):outbound_edges(nil, nil, nil, 10));
+local edges = trans:get_edges(VertexQuery.vertices({outbound.id}):outbound_edges(nil, nil, nil, 10));
 assert(#edges == 1);
-assert(edges[1].key.outbound_id == outbound_id);
+assert(edges[1].key.outbound_id == outbound.id);
 assert(edges[1].key.type == "baz");
-assert(edges[1].key.inbound_id == inbound_id);
+assert(edges[1].key.inbound_id == inbound.id);

--- a/bin/test_scripts/execute/get_edges_bad_high.lua
+++ b/bin/test_scripts/execute/get_edges_bad_high.lua
@@ -1,6 +1,7 @@
 local trans = transaction();
-local id = trans:create_vertex("foo");
-local q = VertexQuery.vertices({id}):outbound_edges("purchased", "bar", 10, 10);
+local v = vertex("foo");
+trans:create_vertex(v);
+local q = VertexQuery.vertices({v.id}):outbound_edges("purchased", "bar", 10, 10);
 
 function test_get_edge_range_bad_high()
     trans:get_edges(q);

--- a/bin/test_scripts/execute/get_edges_bad_low.lua
+++ b/bin/test_scripts/execute/get_edges_bad_low.lua
@@ -1,6 +1,7 @@
 local trans = transaction();
-local id = trans:create_vertex("foo");
-local q = VertexQuery.vertices({id}):outbound_edges("purchased", 10, "bar", 10);
+local v = vertex("foo");
+trans:create_vertex(v);
+local q = VertexQuery.vertices({v.id}):outbound_edges("purchased", 10, "bar", 10);
 
 function test_get_edge_range_bad_high()
     trans:get_edges(q);

--- a/bin/test_scripts/execute/get_vertices.lua
+++ b/bin/test_scripts/execute/get_vertices.lua
@@ -1,15 +1,22 @@
 local trans = transaction();
 
 -- Create some sample data
-local id_1 = trans:create_vertex("foo");
-local id_2 = trans:create_vertex("foo");
-local id_3 = trans:create_vertex("foo");
-local id_4 = trans:create_vertex("foo");
-local id_5 = trans:create_vertex("foo");
-trans:create_edge(EdgeKey.new(id_1, "bar", id_2));
-trans:create_edge(EdgeKey.new(id_2, "bar", id_3));
-trans:create_edge(EdgeKey.new(id_3, "bar", id_4));
-trans:create_edge(EdgeKey.new(id_4, "bar", id_5));
+local v = {
+    vertex("foo"),
+    vertex("foo"),
+    vertex("foo"),
+    vertex("foo"),
+    vertex("foo")  
+};
+
+for _, sv in ipairs(v) do
+    trans:create_vertex(sv);
+end
+
+trans:create_edge(EdgeKey.new(v[1].id, "bar", v[2].id));
+trans:create_edge(EdgeKey.new(v[2].id, "bar", v[3].id));
+trans:create_edge(EdgeKey.new(v[3].id, "bar", v[4].id));
+trans:create_edge(EdgeKey.new(v[4].id, "bar", v[5].id));
 
 function check_vertices(vertices, expected_count, required_vertex_ids)
     if expected_count ~= nil then
@@ -31,17 +38,17 @@ end
 
 -- Ensure we can get all of the vertices
 local vertices = trans:get_vertices(VertexQuery.all("00000000-0000-0000-0000-000000000000", 10000));
-check_vertices(vertices, nil, {[id_1]=true, [id_2]=true, [id_3]=true, [id_4]=true, [id_5]=true});
+check_vertices(vertices, nil, {[v[1].id]=true, [v[2].id]=true, [v[3].id]=true, [v[4].id]=true, [v[5].id]=true});
 
 -- Ensure we can get a specific set of vertices
-local vertices = trans:get_vertices(VertexQuery.vertices({id_1, id_2, id_3}));
-check_vertices(vertices, 3, {[id_1]=true, [id_2]=true, [id_3]=true});
+local vertices = trans:get_vertices(VertexQuery.vertices({v[1].id, v[2].id, v[3].id}));
+check_vertices(vertices, 3, {[v[1].id]=true, [v[2].id]=true, [v[3].id]=true});
 
 -- Ensure we can do a piped query
-local query = VertexQuery.vertices({id_1})
+local query = VertexQuery.vertices({v[1].id})
     :outbound_edges("bar", nil, nil, 1):inbound_vertices(1)
     :outbound_edges(nil, nil, nil, 1):inbound_vertices(1)
     :outbound_edges(nil, nil, nil, 1):inbound_vertices(1)
     :outbound_edges(nil, nil, nil, 1):inbound_vertices(1);
 local vertices = trans:get_vertices(query);
-check_vertices(vertices, 1, {[id_5]=true});
+check_vertices(vertices, 1, {[v[5].id]=true});

--- a/bin/test_scripts/execute/set_and_get_edge.lua
+++ b/bin/test_scripts/execute/set_and_get_edge.lua
@@ -1,10 +1,12 @@
 local trans = transaction();
-local outbound_id = trans:create_vertex("foo");
-local inbound_id = trans:create_vertex("bar");
-local key = EdgeKey.new(outbound_id, "baz", inbound_id);
+local outbound = vertex("foo");
+local inbound = vertex("bar");
+trans:create_vertex(outbound);
+trans:create_vertex(inbound);
+local key = EdgeKey.new(outbound.id, "baz", inbound.id);
 trans:create_edge(key);
 local e = trans:get_edges(EdgeQuery.edges({key}));
 assert(#e == 1);
-assert(e[1].key.outbound_id == outbound_id);
+assert(e[1].key.outbound_id == outbound.id);
 assert(e[1].key.type == "baz");
-assert(e[1].key.inbound_id == inbound_id);
+assert(e[1].key.inbound_id == inbound.id);

--- a/bin/test_scripts/execute/vertex_metadata.lua
+++ b/bin/test_scripts/execute/vertex_metadata.lua
@@ -1,12 +1,13 @@
 local trans = transaction();
-local id = trans:create_vertex("foo");
-local q = VertexQuery.vertices({id});
+local v = vertex("foo");
+trans:create_vertex(v);
+local q = VertexQuery.vertices({v.id});
 
 trans:set_vertex_metadata(q, "script-test-vertex", {foo={true, false}});
 
 local val = trans:get_vertex_metadata(q, "script-test-vertex");
 assert(#val == 1);
-assert(val[1].id == id);
+assert(val[1].id == v.id);
 assert(val[1].value.foo[1] == true);
 assert(val[1].value.foo[2] == false);
 

--- a/bin/tests/batch.rs
+++ b/bin/tests/batch.rs
@@ -137,7 +137,7 @@ impl BatchTransaction {
 }
 
 impl Transaction for BatchTransaction {
-    fn create_vertex(&self, v: &Vertex) -> Result<(), Error> {
+    fn create_vertex(&self, v: &Vertex) -> Result<bool, Error> {
         self.request(&json!({
             "action": "create_vertex",
             "vertex": v

--- a/bin/tests/batch.rs
+++ b/bin/tests/batch.rs
@@ -137,10 +137,10 @@ impl BatchTransaction {
 }
 
 impl Transaction for BatchTransaction {
-    fn create_vertex(&self, t: &Type) -> Result<Uuid, Error> {
+    fn create_vertex(&self, v: &Vertex) -> Result<(), Error> {
         self.request(&json!({
             "action": "create_vertex",
-            "type": t.0
+            "vertex": v
         }))
     }
 

--- a/lib/benches/common/benches.rs
+++ b/lib/benches/common/benches.rs
@@ -6,10 +6,12 @@ where
     D: Datastore<T>,
     T: Transaction,
 {
+    let t = Type::new("bench_create_vertex".to_string()).unwrap();
+
     b.iter(|| {
         let trans = datastore.transaction().unwrap();
-        let t = Type::new("user".to_string()).unwrap();
-        trans.create_vertex(&t).unwrap();
+        let v = Vertex::new(t.clone());
+        trans.create_vertex(&v).unwrap();
     });
 }
 
@@ -20,8 +22,9 @@ where
 {
     let id = {
         let trans = datastore.transaction().unwrap();
-        let t = Type::new("test_name".to_string()).unwrap();
-        trans.create_vertex(&t).unwrap()
+        let t = Type::new("bench_get_vertices".to_string()).unwrap();
+        let v = Vertex::new(t);
+        trans.create_vertex(&v).unwrap()
     };
 
     b.iter(|| {
@@ -36,18 +39,20 @@ where
     D: Datastore<T>,
     T: Transaction,
 {
+    let t = Type::new("bench_create_edge".to_string()).unwrap();
+
     let (outbound_id, inbound_id) = {
         let trans = datastore.transaction().unwrap();
-        let vertex_t = Type::new("test_vertex_type".to_string()).unwrap();
-        let outbound_id = trans.create_vertex(&vertex_t).unwrap();
-        let inbound_id = trans.create_vertex(&vertex_t).unwrap();
-        (outbound_id, inbound_id)
+        let outbound_v = Vertex::new(t.clone());
+        let inbound_v = Vertex::new(t.clone());
+        trans.create_vertex(&outbound_v).unwrap();
+        trans.create_vertex(&inbound_v).unwrap();
+        (outbound_v.id, inbound_v.id)
     };
 
     b.iter(|| {
         let trans = datastore.transaction().unwrap();
-        let edge_t = Type::new("test_vertex_type".to_string()).unwrap();
-        let k = EdgeKey::new(outbound_id, edge_t, inbound_id);
+        let k = EdgeKey::new(outbound_id, t.clone(), inbound_id);
         trans.create_edge(&k).unwrap();
     });
 }
@@ -57,23 +62,22 @@ where
     D: Datastore<T>,
     T: Transaction,
 {
-    let (outbound_id, inbound_id) = {
+    let t = Type::new("bench_get_edges".to_string()).unwrap();
+
+    let key = {
         let trans = datastore.transaction().unwrap();
-        let vertex_t = Type::new("test_vertex_type".to_string()).unwrap();
-        let edge_t = Type::new("test_vertex_type".to_string()).unwrap();
-        let outbound_id = trans.create_vertex(&vertex_t).unwrap();
-        let inbound_id = trans.create_vertex(&vertex_t).unwrap();
-        let key = EdgeKey::new(outbound_id, edge_t, inbound_id);
+        let outbound_v = Vertex::new(t.clone());
+        let inbound_v = Vertex::new(t.clone());
+        trans.create_vertex(&outbound_v).unwrap();
+        trans.create_vertex(&inbound_v).unwrap();
+        let key = EdgeKey::new(outbound_id, t.clone(), inbound_id);
         trans.create_edge(&key).unwrap();
-        (outbound_id, inbound_id)
+        key
     };
 
     b.iter(|| {
         let trans = datastore.transaction().unwrap();
-        let edge_t = Type::new("test_vertex_type".to_string()).unwrap();
-        let q = EdgeQuery::Edges {
-            keys: vec![EdgeKey::new(outbound_id, edge_t, inbound_id)],
-        };
+        let q = EdgeQuery::Edges { keys: vec![key.clone()] };
         trans.get_edges(&q).unwrap();
     });
 }
@@ -83,22 +87,23 @@ where
     D: Datastore<T>,
     T: Transaction,
 {
+    let t = Type::new("bench_get_edge_count".to_string()).unwrap();
+
     let outbound_id = {
         let trans = datastore.transaction().unwrap();
-        let vertex_t = Type::new("test_vertex_type".to_string()).unwrap();
-        let edge_t = Type::new("test_vertex_type".to_string()).unwrap();
-        let outbound_id = trans.create_vertex(&vertex_t).unwrap();
-        let inbound_id = trans.create_vertex(&vertex_t).unwrap();
-        let key = EdgeKey::new(outbound_id, edge_t, inbound_id);
+        let outbound_v = Vertex::new(t.clone());
+        let inbound_v = Vertex::new(t.clone());
+        trans.create_vertex(&outbound_v).unwrap();
+        trans.create_vertex(&inbound_v).unwrap();
+        let key = EdgeKey::new(outbound_id, t.clone(), inbound_id);
         trans.create_edge(&key).unwrap();
         outbound_id
     };
 
     b.iter(|| {
         let trans = datastore.transaction().unwrap();
-        let edge_t = Type::new("test_vertex_type".to_string()).unwrap();
         trans
-            .get_edge_count(outbound_id, Some(&edge_t), EdgeDirection::Outbound)
+            .get_edge_count(outbound_id, Some(&t), EdgeDirection::Outbound)
             .unwrap();
     });
 }

--- a/lib/src/memory/datastore.rs
+++ b/lib/src/memory/datastore.rs
@@ -289,10 +289,15 @@ pub struct MemoryTransaction {
 }
 
 impl Transaction for MemoryTransaction {
-    fn create_vertex(&self, vertex: &models::Vertex) -> Result<()> {
+    fn create_vertex(&self, vertex: &models::Vertex) -> Result<bool> {
         let mut datastore = self.datastore.write().unwrap();
-        datastore.vertices.insert(vertex.id, vertex.t.clone());
-        Ok(())
+
+        if datastore.vertices.contains_key(&vertex.id) {
+            Ok(false)
+        } else {
+            datastore.vertices.insert(vertex.id, vertex.t.clone());
+            Ok(true)
+        }
     }
 
     fn get_vertices(&self, q: &VertexQuery) -> Result<Vec<models::Vertex>> {

--- a/lib/src/models/vertices.rs
+++ b/lib/src/models/vertices.rs
@@ -1,5 +1,6 @@
 use uuid::Uuid;
 use super::types::Type;
+use util::generate_uuid_v1;
 
 /// A vertex.
 ///
@@ -16,13 +17,36 @@ pub struct Vertex {
 }
 
 impl Vertex {
-    /// Creates a new vertex.
+    /// Creates a new vertex with an ID generated via UUIDv1. These vertex IDs
+    /// are trivially guessable and consequently less secure, but likely index
+    /// better depending on the datastore. This method is suggested unless you
+    /// need vertex IDs to not be trivially guessable.
+    ///
+    /// # Arguments
+    ///
+    /// * `t` - The type of the vertex.
+    pub fn new(t: Type) -> Self {
+        Self::with_id(generate_uuid_v1(), t)
+    }
+
+    /// Creates a new vertex with an ID generated via UUIDv4. These vertex IDs
+    /// are not trivially guessable and consequently more secure, but likely
+    /// index worse depending on the datastore.
+    ///
+    /// # Arguments
+    ///
+    /// * `t` - The type of the vertex.
+    pub fn new_secure(t: Type) -> Self {
+        Self::with_id(Uuid::new_v4(), t)
+    }
+
+    /// Creates a new vertex with a specified id.
     ///
     /// # Arguments
     ///
     /// * `id` - The id of the vertex.
     /// * `t` - The type of the vertex.
-    pub fn new(id: Uuid, t: Type) -> Vertex {
+    pub fn with_id(id: Uuid, t: Type) -> Self {
         Vertex { id: id, t: t }
     }
 }

--- a/lib/src/pg/tests.rs
+++ b/lib/src/pg/tests.rs
@@ -14,5 +14,5 @@ full_test_impl!({
         PostgresDatastore::create_schema(connection_string.clone()).unwrap();
     });
 
-    PostgresDatastore::new(Some(1), connection_string, false).unwrap()
+    PostgresDatastore::new(Some(1), connection_string).unwrap()
 });

--- a/lib/src/rdb/datastore.rs
+++ b/lib/src/rdb/datastore.rs
@@ -350,8 +350,15 @@ impl RocksdbTransaction {
 }
 
 impl Transaction for RocksdbTransaction {
-    fn create_vertex(&self, vertex: &models::Vertex) -> Result<()> {
-        VertexManager::new(self.db.clone()).create(vertex)
+    fn create_vertex(&self, vertex: &models::Vertex) -> Result<bool> {
+        let vertex_manager = VertexManager::new(self.db.clone());
+
+        if vertex_manager.exists(vertex.id)? {
+            Ok(false)
+        } else {
+            vertex_manager.create(vertex)?;
+            Ok(true)
+        }
     }
 
     fn get_vertices(&self, q: &VertexQuery) -> Result<Vec<models::Vertex>> {

--- a/lib/src/rdb/tests.rs
+++ b/lib/src/rdb/tests.rs
@@ -23,7 +23,7 @@ fn get_options() -> (String, i32) {
 
 full_test_impl!({
     let (path, max_open_files) = get_options();
-    RocksdbDatastore::new(&path[..], Some(max_open_files), false).unwrap()
+    RocksdbDatastore::new(&path[..], Some(max_open_files)).unwrap()
 });
 
 #[test]

--- a/lib/src/tests/edge.rs
+++ b/lib/src/tests/edge.rs
@@ -14,10 +14,12 @@ where
     let trans = datastore.transaction().unwrap();
 
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
-    let outbound_id = trans.create_vertex(&vertex_t).unwrap();
-    let inbound_id = trans.create_vertex(&vertex_t).unwrap();
+    let outbound_v = models::Vertex::new(vertex_t.clone());
+    let inbound_v = models::Vertex::new(vertex_t.clone());
+    trans.create_vertex(&outbound_v).unwrap();
+    trans.create_vertex(&inbound_v).unwrap();
     let edge_t = models::Type::new("test_edge_type".to_string()).unwrap();
-    let key = models::EdgeKey::new(outbound_id, edge_t.clone(), inbound_id);
+    let key = models::EdgeKey::new(outbound_v.id, edge_t.clone(), inbound_v.id);
 
     // Record the start and end time. Round off the the nanoseconds off the
     // start time, since some implementations may not have that level of
@@ -28,13 +30,13 @@ where
 
     let e = trans
         .get_edges(&EdgeQuery::Edges {
-            keys: vec![EdgeKey::new(outbound_id, edge_t.clone(), inbound_id)],
+            keys: vec![EdgeKey::new(outbound_v.id, edge_t.clone(), inbound_v.id)],
         })
         .unwrap();
     assert_eq!(e.len(), 1);
-    assert_eq!(e[0].key.outbound_id, outbound_id);
+    assert_eq!(e[0].key.outbound_id, outbound_v.id);
     assert_eq!(e[0].key.t, edge_t);
-    assert_eq!(e[0].key.inbound_id, inbound_id);
+    assert_eq!(e[0].key.inbound_id, inbound_v.id);
     assert!(e[0].created_datetime >= start_time);
     assert!(e[0].created_datetime <= end_time);
 }
@@ -47,19 +49,21 @@ where
     let trans = datastore.transaction().unwrap();
 
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
-    let outbound_id = trans.create_vertex(&vertex_t).unwrap();
-    let inbound_id = trans.create_vertex(&vertex_t).unwrap();
+    let outbound_v = models::Vertex::new(vertex_t.clone());
+    let inbound_v = models::Vertex::new(vertex_t.clone());
+    trans.create_vertex(&outbound_v).unwrap();
+    trans.create_vertex(&inbound_v).unwrap();
     let edge_t = models::Type::new("test_edge_type".to_string()).unwrap();
 
     let e = trans
         .get_edges(&EdgeQuery::Edges {
-            keys: vec![EdgeKey::new(outbound_id, edge_t.clone(), Uuid::default())],
+            keys: vec![EdgeKey::new(outbound_v.id, edge_t.clone(), Uuid::default())],
         })
         .unwrap();
     assert_eq!(e.len(), 0);
     let e = trans
         .get_edges(&EdgeQuery::Edges {
-            keys: vec![EdgeKey::new(Uuid::default(), edge_t, inbound_id)],
+            keys: vec![EdgeKey::new(Uuid::default(), edge_t, inbound_v.id)],
         })
         .unwrap();
     assert_eq!(e.len(), 0);
@@ -72,12 +76,14 @@ where
 {
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
     let trans = datastore.transaction().unwrap();
-    let outbound_id = trans.create_vertex(&vertex_t).unwrap();
+    let outbound_v = models::Vertex::new(vertex_t.clone());
+    let inbound_v = models::Vertex::new(vertex_t.clone());
+    trans.create_vertex(&outbound_v).unwrap();
+    trans.create_vertex(&inbound_v).unwrap();
     let edge_t = models::Type::new("test_edge_type".to_string()).unwrap();
-    let inbound_id = trans.create_vertex(&vertex_t).unwrap();
 
     // Set the edge and check
-    let key = models::EdgeKey::new(outbound_id, edge_t.clone(), inbound_id);
+    let key = models::EdgeKey::new(outbound_v.id, edge_t.clone(), inbound_v.id);
     trans.create_edge(&key).unwrap();
     let e = trans
         .get_edges(&EdgeQuery::Edges {
@@ -104,7 +110,7 @@ where
     // single edge
     let e = trans
         .get_edges(&VertexQuery::Vertices {
-            ids: vec![outbound_id],
+            ids: vec![outbound_v.id],
         }.outbound_edges(None, None, None, 10))
         .unwrap();
     assert_eq!(e.len(), 1);
@@ -118,9 +124,10 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
-    let outbound_id = trans.create_vertex(&vertex_t).unwrap();
+    let outbound_v = models::Vertex::new(vertex_t);
+    trans.create_vertex(&outbound_v).unwrap();
     let edge_t = models::Type::new("test_edge_type".to_string()).unwrap();
-    let key = models::EdgeKey::new(outbound_id, edge_t.clone(), Uuid::default());
+    let key = models::EdgeKey::new(outbound_v.id, edge_t.clone(), Uuid::default());
     let result = trans.create_edge(&key);
     assert_eq!(result.unwrap(), false);
 }
@@ -132,11 +139,13 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_edge_type".to_string()).unwrap();
-    let outbound_id = trans.create_vertex(&vertex_t).unwrap();
-    let inbound_id = trans.create_vertex(&vertex_t).unwrap();
+    let outbound_v = models::Vertex::new(vertex_t.clone());
+    let inbound_v = models::Vertex::new(vertex_t.clone());
+    trans.create_vertex(&outbound_v).unwrap();
+    trans.create_vertex(&inbound_v).unwrap();
 
     let edge_t = models::Type::new("test_edge_type".to_string()).unwrap();
-    let key = models::EdgeKey::new(outbound_id, edge_t.clone(), inbound_id);
+    let key = models::EdgeKey::new(outbound_v.id, edge_t.clone(), inbound_v.id);
     trans.create_edge(&key).unwrap();
     trans
         .delete_edges(&EdgeQuery::Edges {
@@ -156,11 +165,12 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_edge_type".to_string()).unwrap();
-    let outbound_id = trans.create_vertex(&vertex_t).unwrap();
+    let outbound_v = models::Vertex::new(vertex_t.clone());
+    trans.create_vertex(&outbound_v).unwrap();
     let edge_t = models::Type::new("test_edge_type".to_string()).unwrap();
     trans
         .delete_edges(&EdgeQuery::Edges {
-            keys: vec![EdgeKey::new(outbound_id, edge_t, Uuid::default())],
+            keys: vec![EdgeKey::new(outbound_v.id, edge_t, Uuid::default())],
         })
         .unwrap();
 }
@@ -350,13 +360,13 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
+    let outbound_v = models::Vertex::new(vertex_t);
+    trans.create_vertex(&outbound_v).unwrap();
 
-    let inserted_id_1 = trans.create_vertex(&vertex_t).unwrap();
-    let inserted_id_2 = create_edge_from::<D, T>(&trans, inserted_id_1);
+    let inbound_id = create_edge_from::<D, T>(&trans, outbound_v.id);
 
-    // This query should get `inserted_id_2`
     let query_1 = VertexQuery::Vertices {
-        ids: vec![inserted_id_1],
+        ids: vec![outbound_v.id],
     }.outbound_edges(
         Some(models::Type::new("test_edge_type".to_string()).unwrap()),
         None,
@@ -368,13 +378,12 @@ where
     assert_eq!(
         range[0].key,
         models::EdgeKey::new(
-            inserted_id_1,
+            outbound_v.id,
             models::Type::new("test_edge_type".to_string()).unwrap(),
-            inserted_id_2
+            inbound_id
         )
     );
 
-    // This query should get `inserted_id_1`
     let query_2 = query_1.inbound_vertices(1).inbound_edges(
         Some(models::Type::new("test_edge_type".to_string()).unwrap()),
         None,
@@ -386,9 +395,9 @@ where
     assert_eq!(
         range[0].key,
         models::EdgeKey::new(
-            inserted_id_1,
+            outbound_v.id,
             models::Type::new("test_edge_type".to_string()).unwrap(),
-            inserted_id_2
+            inbound_id
         )
     );
 }

--- a/lib/src/tests/metadata.rs
+++ b/lib/src/tests/metadata.rs
@@ -1,4 +1,4 @@
-use super::super::{Datastore, EdgeKey, EdgeQuery, Transaction, Type, VertexQuery};
+use super::super::{Datastore, EdgeKey, EdgeQuery, Transaction, Type, Vertex, VertexQuery};
 use util::generate_random_secret;
 use uuid::Uuid;
 use serde_json::Value as JsonValue;
@@ -45,10 +45,11 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let t = Type::new("test_edge_type".to_string()).unwrap();
-    let owner_id = trans.create_vertex(&t).unwrap();
+    let v = Vertex::new(t);
+    trans.create_vertex(&v).unwrap();
     let name = format!("vertex-metadata-{}", generate_random_secret(8));
     let q = VertexQuery::Vertices {
-        ids: vec![owner_id],
+        ids: vec![v.id],
     };
 
     // Check to make sure there's no initial value
@@ -61,7 +62,7 @@ where
         .unwrap();
     let result = trans.get_vertex_metadata(&q, &name).unwrap();
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].id, owner_id);
+    assert_eq!(result[0].id, v.id);
     assert_eq!(result[0].value, JsonValue::Bool(true));
 
     // Set and get the value as false
@@ -70,7 +71,7 @@ where
         .unwrap();
     let result = trans.get_vertex_metadata(&q, &name).unwrap();
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].id, owner_id);
+    assert_eq!(result[0].id, v.id);
     assert_eq!(result[0].value, JsonValue::Bool(false));
 
     // Delete & check that it's deleted
@@ -106,11 +107,11 @@ where
     };
     trans.delete_vertex_metadata(&q, "foo").unwrap();
 
-    let vertex_id = trans
-        .create_vertex(&Type::new("foo".to_string()).unwrap())
-        .unwrap();
+    let v = Vertex::new(Type::new("foo".to_string()).unwrap());
+    trans.create_vertex(&v).unwrap();
+
     let q = VertexQuery::Vertices {
-        ids: vec![vertex_id],
+        ids: vec![v.id],
     };
     trans.delete_vertex_metadata(&q, "foo").unwrap();
 }
@@ -122,10 +123,12 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = Type::new("test_edge_type".to_string()).unwrap();
-    let outbound_id = trans.create_vertex(&vertex_t).unwrap();
-    let inbound_id = trans.create_vertex(&vertex_t).unwrap();
+    let outbound_v = Vertex::new(vertex_t.clone());
+    let inbound_v = Vertex::new(vertex_t.clone());
+    trans.create_vertex(&outbound_v).unwrap();
+    trans.create_vertex(&inbound_v).unwrap();
     let edge_t = Type::new("test_edge_type".to_string()).unwrap();
-    let key = EdgeKey::new(outbound_id, edge_t.clone(), inbound_id);
+    let key = EdgeKey::new(outbound_v.id, edge_t.clone(), inbound_v.id);
     let q = EdgeQuery::Edges {
         keys: vec![key.clone()],
     };
@@ -200,16 +203,15 @@ where
     };
     trans.delete_edge_metadata(&q, "bar").unwrap();
 
-    let outbound_id = trans
-        .create_vertex(&Type::new("foo".to_string()).unwrap())
-        .unwrap();
-    let inbound_id = trans
-        .create_vertex(&Type::new("bar".to_string()).unwrap())
-        .unwrap();
+    let outbound_v = Vertex::new(Type::new("foo".to_string()).unwrap());
+    let inbound_v = Vertex::new(Type::new("foo".to_string()).unwrap());
+    trans.create_vertex(&outbound_v).unwrap();
+    trans.create_vertex(&inbound_v).unwrap();
+
     let key = EdgeKey::new(
-        outbound_id,
+        outbound_v.id,
         Type::new("baz".to_string()).unwrap(),
-        inbound_id,
+        inbound_v.id,
     );
     trans.create_edge(&key).unwrap();
     trans

--- a/lib/src/tests/util.rs
+++ b/lib/src/tests/util.rs
@@ -10,11 +10,12 @@ where
     T: Transaction,
 {
     let inbound_vertex_t = models::Type::new("test_inbound_vertex_type".to_string()).unwrap();
-    let inbound_id = trans.create_vertex(&inbound_vertex_t).unwrap();
+    let inbound_v = models::Vertex::new(inbound_vertex_t);
+    trans.create_vertex(&inbound_v).unwrap();
     let edge_t = models::Type::new("test_edge_type".to_string()).unwrap();
-    let key = models::EdgeKey::new(outbound_id, edge_t, inbound_id);
+    let key = models::EdgeKey::new(outbound_id, edge_t, inbound_v.id);
     trans.create_edge(&key).unwrap();
-    inbound_id
+    inbound_v.id
 }
 
 pub fn create_edges<D, T>(datastore: &mut D) -> (Uuid, [Uuid; 5])
@@ -24,16 +25,17 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let outbound_vertex_t = models::Type::new("test_outbound_vertex_type".to_string()).unwrap();
-    let outbound_id = trans.create_vertex(&outbound_vertex_t).unwrap();
+    let outbound_v = models::Vertex::new(outbound_vertex_t);
+    trans.create_vertex(&outbound_v).unwrap();
     let inbound_ids: [Uuid; 5] = [
-        create_edge_from::<D, T>(&trans, outbound_id),
-        create_edge_from::<D, T>(&trans, outbound_id),
-        create_edge_from::<D, T>(&trans, outbound_id),
-        create_edge_from::<D, T>(&trans, outbound_id),
-        create_edge_from::<D, T>(&trans, outbound_id),
+        create_edge_from::<D, T>(&trans, outbound_v.id),
+        create_edge_from::<D, T>(&trans, outbound_v.id),
+        create_edge_from::<D, T>(&trans, outbound_v.id),
+        create_edge_from::<D, T>(&trans, outbound_v.id),
+        create_edge_from::<D, T>(&trans, outbound_v.id),
     ];
 
-    (outbound_id, inbound_ids)
+    (outbound_v.id, inbound_ids)
 }
 
 pub fn create_time_range_queryable_edges<D, T>(
@@ -45,29 +47,30 @@ where
 {
     let trans = datastore.transaction().unwrap();
     let outbound_vertex_t = models::Type::new("test_outbound_vertex_type".to_string()).unwrap();
-    let outbound_id = trans.create_vertex(&outbound_vertex_t).unwrap();
+    let outbound_v = models::Vertex::new(outbound_vertex_t);
+    trans.create_vertex(&outbound_v).unwrap();
 
-    create_edge_from::<D, T>(&trans, outbound_id);
-    create_edge_from::<D, T>(&trans, outbound_id);
-    create_edge_from::<D, T>(&trans, outbound_id);
-    create_edge_from::<D, T>(&trans, outbound_id);
-    create_edge_from::<D, T>(&trans, outbound_id);
+    create_edge_from::<D, T>(&trans, outbound_v.id);
+    create_edge_from::<D, T>(&trans, outbound_v.id);
+    create_edge_from::<D, T>(&trans, outbound_v.id);
+    create_edge_from::<D, T>(&trans, outbound_v.id);
+    create_edge_from::<D, T>(&trans, outbound_v.id);
 
     let start_time = Utc::now();
     let inbound_ids = [
-        create_edge_from::<D, T>(&trans, outbound_id),
-        create_edge_from::<D, T>(&trans, outbound_id),
-        create_edge_from::<D, T>(&trans, outbound_id),
-        create_edge_from::<D, T>(&trans, outbound_id),
-        create_edge_from::<D, T>(&trans, outbound_id),
+        create_edge_from::<D, T>(&trans, outbound_v.id),
+        create_edge_from::<D, T>(&trans, outbound_v.id),
+        create_edge_from::<D, T>(&trans, outbound_v.id),
+        create_edge_from::<D, T>(&trans, outbound_v.id),
+        create_edge_from::<D, T>(&trans, outbound_v.id),
     ];
     let end_time = Utc::now();
 
-    create_edge_from::<D, T>(&trans, outbound_id);
-    create_edge_from::<D, T>(&trans, outbound_id);
-    create_edge_from::<D, T>(&trans, outbound_id);
-    create_edge_from::<D, T>(&trans, outbound_id);
-    create_edge_from::<D, T>(&trans, outbound_id);
+    create_edge_from::<D, T>(&trans, outbound_v.id);
+    create_edge_from::<D, T>(&trans, outbound_v.id);
+    create_edge_from::<D, T>(&trans, outbound_v.id);
+    create_edge_from::<D, T>(&trans, outbound_v.id);
+    create_edge_from::<D, T>(&trans, outbound_v.id);
 
-    (outbound_id, start_time, end_time, inbound_ids)
+    (outbound_v.id, start_time, end_time, inbound_ids)
 }

--- a/lib/src/traits.rs
+++ b/lib/src/traits.rs
@@ -28,8 +28,8 @@ pub trait Transaction {
     /// Creates a new vertex.
     ///
     /// # Arguments
-    /// * `t` - The type of the vertex.
-    fn create_vertex(&self, t: &models::Type) -> Result<Uuid>;
+    /// * `vertex`: The vertex to create.
+    fn create_vertex(&self, vertex: &models::Vertex) -> Result<()>;
 
     /// Gets a range of vertices specified by a query.
     ///

--- a/lib/src/traits.rs
+++ b/lib/src/traits.rs
@@ -29,7 +29,7 @@ pub trait Transaction {
     ///
     /// # Arguments
     /// * `vertex`: The vertex to create.
-    fn create_vertex(&self, vertex: &models::Vertex) -> Result<()>;
+    fn create_vertex(&self, vertex: &models::Vertex) -> Result<bool>;
 
     /// Gets a range of vertices specified by a query.
     ///

--- a/lib/src/util.rs
+++ b/lib/src/util.rs
@@ -12,36 +12,17 @@ lazy_static! {
     static ref CONTEXT: UuidV1Context = UuidV1Context::new(0);
 }
 
-#[derive(Debug)]
-pub enum UuidGenerator {
-    V1,
-    V4,
-}
+/// Generates a UUID v1. this utility method uses a shared context and node ID
+/// to help ensure generated UUIDs are unique.
+pub fn generate_uuid_v1() -> Uuid {
+    let now = Utc::now();
 
-impl UuidGenerator {
-    pub fn new(secure: bool) -> Self {
-        if secure {
-            UuidGenerator::V4
-        } else {
-            UuidGenerator::V1
-        }
-    }
-
-    pub fn next(&self) -> Uuid {
-        match *self {
-            UuidGenerator::V1 => {
-                let now = Utc::now();
-
-                Uuid::new_v1(
-                    &CONTEXT,
-                    now.timestamp() as u64,
-                    now.timestamp_subsec_nanos(),
-                    &NODE_ID,
-                ).expect("Expected to be able to generate a UUID")
-            }
-            UuidGenerator::V4 => Uuid::new_v4(),
-        }
-    }
+    Uuid::new_v1(
+        &CONTEXT,
+        now.timestamp() as u64,
+        now.timestamp_subsec_nanos(),
+        &NODE_ID,
+    ).expect("Expected to be able to generate a UUID")
 }
 
 /// Generates a securely random string consisting of letters (uppercase and
@@ -95,21 +76,16 @@ pub fn nanos_since_epoch(datetime: &DateTime<Utc>) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{generate_random_secret, nanos_since_epoch, next_uuid, UuidGenerator};
+    use super::{generate_uuid_v1, generate_random_secret, nanos_since_epoch, next_uuid};
     use regex::Regex;
     use uuid::Uuid;
     use core::str::FromStr;
     use chrono::{DateTime, NaiveDateTime, Utc};
 
     #[test]
-    fn should_generate_uuids() {
-        let generator = UuidGenerator::new(false);
-        let first = generator.next();
-        let second = generator.next();
-        assert_ne!(first, second);
-        let generator = UuidGenerator::new(true);
-        let first = generator.next();
-        let second = generator.next();
+    fn should_generate_new_uuid_v1() {
+        let first = generate_uuid_v1();
+        let second = generate_uuid_v1();
         assert_ne!(first, second);
     }
 

--- a/lib/test.sh
+++ b/lib/test.sh
@@ -32,5 +32,5 @@ trap cleanup EXIT
 
 dropdb --if-exists indradb_test
 createdb --owner=$PG_USER indradb_test
-cargo update
+#cargo update
 cargo $ACTION --all-features $TEST_NAME

--- a/lib/test.sh
+++ b/lib/test.sh
@@ -32,5 +32,5 @@ trap cleanup EXIT
 
 dropdb --if-exists indradb_test
 createdb --owner=$PG_USER indradb_test
-#cargo update
+cargo update
 cargo $ACTION --all-features $TEST_NAME


### PR DESCRIPTION
This allows library users to choose vertex IDs, which should be useful in the case of users who want to:

1) Use a different or custom UUID generating algorithm.
2) Use already existing UUIDs.
3) Generate UUIDs client-side.