### PR TITLE
Get rid of automatic vertex ID generation

### DIFF
--- a/bin/src/server/http/endpoints.rs
+++ b/bin/src/server/http/endpoints.rs
@@ -117,14 +117,7 @@ pub fn transaction(req: &mut Request) -> IronResult<Response> {
 }
 
 fn create_vertex(trans: &ProxyTransaction, item: &serde_json::Map<String, JsonValue>) -> Result<JsonValue, IronError> {
-    let t = get_optional_json_obj_value::<Type>(item, "type")?;
-
-    let v = if let Some(t) = t {
-        Vertex::new(t)
-    } else {
-        get_json_obj_value::<Vertex>(item, "vertex")?
-    };
-
+    let v = get_json_obj_value::<Vertex>(item, "vertex")?;
     execute_item(trans.create_vertex(&v))
 }
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -33,7 +33,7 @@ regex = "~0.2.5"
 lazy_static = "^1.0.0"
 byteorder = "^1.2.1"
 chrono = { version = "0.4.0", features = ["serde"] }
-uuid = { version = ">=0.5,<0.6", features = ["serde", "v1", "v4"] }
+uuid = { version = ">=0.5,<0.6", features = ["serde", "v1"] }
 
 # Postgres dependencies
 postgres = { version = "0.15", optional = true, features = ["with-serde_json", "with-chrono", "with-uuid"] }

--- a/lib/src/models/vertices.rs
+++ b/lib/src/models/vertices.rs
@@ -29,17 +29,6 @@ impl Vertex {
         Self::with_id(generate_uuid_v1(), t)
     }
 
-    /// Creates a new vertex with an ID generated via UUIDv4. These vertex IDs
-    /// are not trivially guessable and consequently more secure, but likely
-    /// index worse depending on the datastore.
-    ///
-    /// # Arguments
-    ///
-    /// * `t` - The type of the vertex.
-    pub fn new_secure(t: Type) -> Self {
-        Self::with_id(Uuid::new_v4(), t)
-    }
-
     /// Creates a new vertex with a specified id.
     ///
     /// # Arguments


### PR DESCRIPTION
This was a special case deviation between the HTTP API and the library, but wasn't very helpful because the UUID generated for the vertex wasn't returned anyways.