### PR TITLE
Cleanup rocksdb implementation

### DIFF
--- a/lib/src/rdb/datastore.rs
+++ b/lib/src/rdb/datastore.rs
@@ -105,7 +105,7 @@ impl RocksdbTransaction {
         Ok(RocksdbTransaction { db })
     }
 
-    fn vertex_query_to_iterator(&self, q: VertexQuery) -> Result<Box<dyn Iterator<Item=Result<VertexItem>>>> {
+    fn vertex_query_to_iterator(&self, q: VertexQuery) -> Result<Box<dyn Iterator<Item = Result<VertexItem>>>> {
         let vertex_manager = VertexManager::new(self.db.clone());
 
         match q {
@@ -156,16 +156,18 @@ impl RocksdbTransaction {
         }
     }
 
-    fn edge_query_to_iterator(&self, q: EdgeQuery) -> Result<Box<dyn Iterator<Item=Result<EdgeRangeItem>>>> {
+    fn edge_query_to_iterator(&self, q: EdgeQuery) -> Result<Box<dyn Iterator<Item = Result<EdgeRangeItem>>>> {
         match q {
             EdgeQuery::Edges { keys } => {
                 let edge_manager = EdgeManager::new(self.db.clone());
 
-                let edges = keys.into_iter().map(move |key| match edge_manager.get(key.outbound_id, &key.t, key.inbound_id)? {
-                    Some(update_datetime) => {
-                        Ok(Some((key.outbound_id, key.t.clone(), update_datetime, key.inbound_id)))
+                let edges = keys.into_iter().map(move |key| {
+                    match edge_manager.get(key.outbound_id, &key.t, key.inbound_id)? {
+                        Some(update_datetime) => {
+                            Ok(Some((key.outbound_id, key.t.clone(), update_datetime, key.inbound_id)))
+                        }
+                        None => Ok(None),
                     }
-                    None => Ok(None),
                 });
 
                 let iterator = self.remove_nones_from_iterator(edges);
@@ -240,8 +242,9 @@ impl RocksdbTransaction {
         }
     }
 
-    fn remove_nones_from_iterator<I, T>(&self, iterator: I) -> impl Iterator<Item=Result<T>>
-    where I: Iterator<Item=Result<Option<T>>>
+    fn remove_nones_from_iterator<I, T>(&self, iterator: I) -> impl Iterator<Item = Result<T>>
+    where
+        I: Iterator<Item = Result<Option<T>>>,
     {
         let filtered = iterator.filter(|item| match *item {
             Err(_) | Ok(Some(_)) => true,
@@ -257,10 +260,10 @@ impl RocksdbTransaction {
         Box::new(mapped)
     }
 
-    fn handle_vertex_id_iterator<T: Iterator<Item=Result<Uuid>>>(
+    fn handle_vertex_id_iterator<T: Iterator<Item = Result<Uuid>>>(
         &self,
         iterator: T,
-    ) -> impl Iterator<Item=Result<VertexItem>> {
+    ) -> impl Iterator<Item = Result<VertexItem>> {
         let vertex_manager = VertexManager::new(self.db.clone());
 
         let mapped = iterator.map(move |item| {

--- a/lib/src/rdb/keys.rs
+++ b/lib/src/rdb/keys.rs
@@ -72,19 +72,13 @@ pub fn build_key(components: &[KeyComponent]) -> Box<[u8]> {
     cursor.into_inner().into_boxed_slice()
 }
 
-pub fn parse_uuid_key(key: Box<[u8]>) -> Uuid {
-    debug_assert_eq!(key.len(), 16);
-    let mut cursor = Cursor::new(key);
-    read_uuid(&mut cursor)
-}
-
 pub fn read_uuid(cursor: &mut Cursor<Box<[u8]>>) -> Uuid {
     let mut buf: [u8; 16] = [0; 16];
     cursor.read_exact(&mut buf).unwrap();
     Uuid::from_bytes(&buf).unwrap()
 }
 
-pub fn read_short_sized_string(cursor: &mut Cursor<Box<[u8]>>) -> String {
+pub fn read_type(cursor: &mut Cursor<Box<[u8]>>) -> models::Type {
     let t_len = {
         let mut buf: [u8; 1] = [0; 1];
         cursor.read_exact(&mut buf).unwrap();
@@ -93,11 +87,8 @@ pub fn read_short_sized_string(cursor: &mut Cursor<Box<[u8]>>) -> String {
 
     let mut buf = vec![0u8; t_len];
     cursor.read_exact(&mut buf).unwrap();
-    str::from_utf8(&buf).unwrap().to_string()
-}
-
-pub fn read_type(mut cursor: &mut Cursor<Box<[u8]>>) -> models::Type {
-    models::Type::new(read_short_sized_string(&mut cursor)).unwrap()
+    let s = str::from_utf8(&buf).unwrap().to_string();
+    models::Type::new(s).unwrap()
 }
 
 pub fn read_unsized_string(cursor: &mut Cursor<Box<[u8]>>) -> String {

--- a/lib/src/rdb/managers.rs
+++ b/lib/src/rdb/managers.rs
@@ -45,7 +45,7 @@ fn get_json(db: &DB, cf: ColumnFamily, key: &[u8]) -> Result<Option<JsonValue>> 
     }
 }
 
-fn take_while_prefixed(iterator: DBIterator, prefix: Box<[u8]>) -> impl Iterator<Item=(Box<[u8]>, Box<[u8]>)> {
+fn take_while_prefixed(iterator: DBIterator, prefix: Box<[u8]>) -> impl Iterator<Item = (Box<[u8]>, Box<[u8]>)> {
     iterator.take_while(move |item| -> bool {
         let (ref k, _) = *item;
         k.starts_with(&prefix)
@@ -56,7 +56,7 @@ fn iterate_metadata_for_owner(
     db: &DB,
     cf: ColumnFamily,
     id: Uuid,
-) -> Result<impl Iterator<Item=Result<OwnedMetadataItem>>> {
+) -> Result<impl Iterator<Item = Result<OwnedMetadataItem>>> {
     let prefix = build_key(&[KeyComponent::Uuid(id)]);
     let iterator = db.iterator_cf(cf, IteratorMode::From(&prefix, Direction::Forward))?;
     let filtered = take_while_prefixed(iterator, prefix);
@@ -100,7 +100,7 @@ impl VertexManager {
         }
     }
 
-    fn iterate(&self, iterator: DBIterator) -> Result<impl Iterator<Item=Result<VertexItem>>> {
+    fn iterate(&self, iterator: DBIterator) -> Result<impl Iterator<Item = Result<VertexItem>>> {
         Ok(iterator.map(|item| -> Result<VertexItem> {
             let (k, v) = item;
             let id = parse_uuid_key(k);
@@ -109,7 +109,7 @@ impl VertexManager {
         }))
     }
 
-    pub fn iterate_for_range(&self, id: Uuid) -> Result<impl Iterator<Item=Result<VertexItem>>> {
+    pub fn iterate_for_range(&self, id: Uuid) -> Result<impl Iterator<Item = Result<VertexItem>>> {
         let low_key = build_key(&[KeyComponent::Uuid(id)]);
         let iterator = self
             .db
@@ -288,11 +288,7 @@ impl EdgeRangeManager {
         ])
     }
 
-    fn iterate(
-        &self,
-        iterator: DBIterator,
-        prefix: Box<[u8]>,
-    ) -> Result<impl Iterator<Item=Result<EdgeRangeItem>>> {
+    fn iterate(&self, iterator: DBIterator, prefix: Box<[u8]>) -> Result<impl Iterator<Item = Result<EdgeRangeItem>>> {
         let filtered = take_while_prefixed(iterator, prefix);
 
         Ok(filtered.map(move |item| -> Result<EdgeRangeItem> {
@@ -311,7 +307,7 @@ impl EdgeRangeManager {
         id: Uuid,
         t: Option<&models::Type>,
         high: Option<DateTime<Utc>>,
-    ) -> Result<Box<dyn Iterator<Item=Result<EdgeRangeItem>>>> {
+    ) -> Result<Box<dyn Iterator<Item = Result<EdgeRangeItem>>>> {
         match t {
             Some(t) => {
                 let high = high.unwrap_or_else(|| *MAX_DATETIME);
@@ -353,7 +349,7 @@ impl EdgeRangeManager {
         }
     }
 
-    pub fn iterate_for_owner(&self, id: Uuid) -> Result<impl Iterator<Item=Result<EdgeRangeItem>>> {
+    pub fn iterate_for_owner(&self, id: Uuid) -> Result<impl Iterator<Item = Result<EdgeRangeItem>>> {
         let prefix = build_key(&[KeyComponent::Uuid(id)]);
         let iterator = self
             .db
@@ -405,7 +401,7 @@ impl VertexMetadataManager {
         build_key(&[KeyComponent::Uuid(vertex_id), KeyComponent::UnsizedString(name)])
     }
 
-    pub fn iterate_for_owner(&self, vertex_id: Uuid) -> Result<impl Iterator<Item=Result<OwnedMetadataItem>>> {
+    pub fn iterate_for_owner(&self, vertex_id: Uuid) -> Result<impl Iterator<Item = Result<OwnedMetadataItem>>> {
         iterate_metadata_for_owner(&self.db, self.cf, vertex_id)
     }
 
@@ -453,7 +449,7 @@ impl EdgeMetadataManager {
         outbound_id: Uuid,
         t: &'a models::Type,
         inbound_id: Uuid,
-    ) -> Result<Box<dyn Iterator<Item=Result<EdgeMetadataItem>> + 'a>> {
+    ) -> Result<Box<dyn Iterator<Item = Result<EdgeMetadataItem>> + 'a>> {
         let prefix = build_key(&[
             KeyComponent::Uuid(outbound_id),
             KeyComponent::Type(t),

--- a/lib/src/rdb/managers.rs
+++ b/lib/src/rdb/managers.rs
@@ -306,12 +306,12 @@ impl EdgeRangeManager {
         }))
     }
 
-    pub fn iterate_for_range<'a>(
+    pub fn iterate_for_range(
         &self,
         id: Uuid,
         t: Option<&models::Type>,
         high: Option<DateTime<Utc>>,
-    ) -> Result<Box<Iterator<Item = Result<EdgeRangeItem>> + 'a>> {
+    ) -> Result<Box<dyn Iterator<Item=Result<EdgeRangeItem>>>> {
         match t {
             Some(t) => {
                 let high = high.unwrap_or_else(|| *MAX_DATETIME);
@@ -453,7 +453,7 @@ impl EdgeMetadataManager {
         outbound_id: Uuid,
         t: &'a models::Type,
         inbound_id: Uuid,
-    ) -> Result<Box<Iterator<Item = Result<EdgeMetadataItem>> + 'a>> {
+    ) -> Result<Box<dyn Iterator<Item = Result<EdgeMetadataItem>> + 'a>> {
         let prefix = build_key(&[
             KeyComponent::Uuid(outbound_id),
             KeyComponent::Type(t),

--- a/lib/src/rdb/managers.rs
+++ b/lib/src/rdb/managers.rs
@@ -103,7 +103,13 @@ impl VertexManager {
     fn iterate(&self, iterator: DBIterator) -> Result<impl Iterator<Item = Result<VertexItem>>> {
         Ok(iterator.map(|item| -> Result<VertexItem> {
             let (k, v) = item;
-            let id = parse_uuid_key(k);
+
+            let id = {
+                debug_assert_eq!(k.len(), 16);
+                let mut cursor = Cursor::new(k);
+                read_uuid(&mut cursor)
+            };
+
             let value: models::Type = bincode::deserialize(&v.to_owned()[..])?;
             Ok((id, value))
         }))

--- a/lib/src/rdb/managers.rs
+++ b/lib/src/rdb/managers.rs
@@ -13,7 +13,6 @@ use std::sync::Arc;
 use std::u8;
 use uuid::Uuid;
 
-pub type DBIteratorItem = (Box<[u8]>, Box<[u8]>);
 pub type OwnedMetadataItem = ((Uuid, String), JsonValue);
 pub type VertexItem = (Uuid, models::Type);
 pub type EdgeRangeItem = (Uuid, models::Type, DateTime<Utc>, Uuid);
@@ -46,25 +45,23 @@ fn get_json(db: &DB, cf: ColumnFamily, key: &[u8]) -> Result<Option<JsonValue>> 
     }
 }
 
-fn take_while_prefixed<'a>(iterator: DBIterator, prefix: Box<[u8]>) -> Box<Iterator<Item = DBIteratorItem> + 'a> {
-    let filtered = iterator.take_while(move |item| -> bool {
+fn take_while_prefixed(iterator: DBIterator, prefix: Box<[u8]>) -> impl Iterator<Item=(Box<[u8]>, Box<[u8]>)> {
+    iterator.take_while(move |item| -> bool {
         let (ref k, _) = *item;
         k.starts_with(&prefix)
-    });
-
-    Box::new(filtered)
+    })
 }
 
-fn iterate_metadata_for_owner<'a>(
+fn iterate_metadata_for_owner(
     db: &DB,
     cf: ColumnFamily,
     id: Uuid,
-) -> Result<Box<Iterator<Item = Result<OwnedMetadataItem>> + 'a>> {
+) -> Result<impl Iterator<Item=Result<OwnedMetadataItem>>> {
     let prefix = build_key(&[KeyComponent::Uuid(id)]);
     let iterator = db.iterator_cf(cf, IteratorMode::From(&prefix, Direction::Forward))?;
     let filtered = take_while_prefixed(iterator, prefix);
 
-    let mapped = filtered.map(move |item| -> Result<((Uuid, String), JsonValue)> {
+    Ok(filtered.map(move |item| -> Result<((Uuid, String), JsonValue)> {
         let (k, v) = item;
         let mut cursor = Cursor::new(k);
         let owner_id = read_uuid(&mut cursor);
@@ -72,9 +69,7 @@ fn iterate_metadata_for_owner<'a>(
         let name = read_unsized_string(&mut cursor);
         let value = json_deserialize_value(&v.to_owned()[..])?;
         Ok(((owner_id, name), value))
-    });
-
-    Ok(Box::new(mapped))
+    }))
 }
 
 pub struct VertexManager {
@@ -105,18 +100,16 @@ impl VertexManager {
         }
     }
 
-    fn iterate<'a>(&self, iterator: DBIterator) -> Result<Box<Iterator<Item = Result<VertexItem>> + 'a>> {
-        let mapped = iterator.map(|item| -> Result<VertexItem> {
+    fn iterate(&self, iterator: DBIterator) -> Result<impl Iterator<Item=Result<VertexItem>>> {
+        Ok(iterator.map(|item| -> Result<VertexItem> {
             let (k, v) = item;
             let id = parse_uuid_key(k);
             let value: models::Type = bincode::deserialize(&v.to_owned()[..])?;
             Ok((id, value))
-        });
-
-        Ok(Box::new(mapped))
+        }))
     }
 
-    pub fn iterate_for_range<'a>(&self, id: Uuid) -> Result<Box<Iterator<Item = Result<VertexItem>> + 'a>> {
+    pub fn iterate_for_range(&self, id: Uuid) -> Result<impl Iterator<Item = Result<VertexItem>>> {
         let low_key = build_key(&[KeyComponent::Uuid(id)]);
         let iterator = self
             .db
@@ -295,14 +288,14 @@ impl EdgeRangeManager {
         ])
     }
 
-    fn iterate<'a>(
+    fn iterate(
         &self,
         iterator: DBIterator,
         prefix: Box<[u8]>,
-    ) -> Result<Box<Iterator<Item = Result<EdgeRangeItem>> + 'a>> {
+    ) -> Result<impl Iterator<Item=Result<EdgeRangeItem>>> {
         let filtered = take_while_prefixed(iterator, prefix);
 
-        let mapped = filtered.map(move |item| -> Result<EdgeRangeItem> {
+        Ok(filtered.map(move |item| -> Result<EdgeRangeItem> {
             let (k, _) = item;
             let mut cursor = Cursor::new(k);
             let first_id = read_uuid(&mut cursor);
@@ -310,9 +303,7 @@ impl EdgeRangeManager {
             let update_datetime = read_datetime(&mut cursor);
             let second_id = read_uuid(&mut cursor);
             Ok((first_id, t, update_datetime, second_id))
-        });
-
-        Ok(Box::new(mapped))
+        }))
     }
 
     pub fn iterate_for_range<'a>(
@@ -333,7 +324,7 @@ impl EdgeRangeManager {
                 let iterator = self
                     .db
                     .iterator_cf(self.cf, IteratorMode::From(&low_key, Direction::Forward))?;
-                self.iterate(iterator, prefix)
+                Ok(Box::new(self.iterate(iterator, prefix)?))
             }
             None => {
                 let prefix = build_key(&[KeyComponent::Uuid(id)]);
@@ -356,13 +347,13 @@ impl EdgeRangeManager {
 
                     Ok(Box::new(filtered))
                 } else {
-                    Ok(mapped)
+                    Ok(Box::new(mapped))
                 }
             }
         }
     }
 
-    pub fn iterate_for_owner<'a>(&self, id: Uuid) -> Result<Box<Iterator<Item = Result<EdgeRangeItem>> + 'a>> {
+    pub fn iterate_for_owner(&self, id: Uuid) -> Result<impl Iterator<Item=Result<EdgeRangeItem>>> {
         let prefix = build_key(&[KeyComponent::Uuid(id)]);
         let iterator = self
             .db
@@ -414,7 +405,7 @@ impl VertexMetadataManager {
         build_key(&[KeyComponent::Uuid(vertex_id), KeyComponent::UnsizedString(name)])
     }
 
-    pub fn iterate_for_owner(&self, vertex_id: Uuid) -> Result<Box<Iterator<Item = Result<OwnedMetadataItem>>>> {
+    pub fn iterate_for_owner(&self, vertex_id: Uuid) -> Result<impl Iterator<Item=Result<OwnedMetadataItem>>> {
         iterate_metadata_for_owner(&self.db, self.cf, vertex_id)
     }
 

--- a/lib/src/rdb/managers.rs
+++ b/lib/src/rdb/managers.rs
@@ -109,7 +109,7 @@ impl VertexManager {
         }))
     }
 
-    pub fn iterate_for_range(&self, id: Uuid) -> Result<impl Iterator<Item = Result<VertexItem>>> {
+    pub fn iterate_for_range(&self, id: Uuid) -> Result<impl Iterator<Item=Result<VertexItem>>> {
         let low_key = build_key(&[KeyComponent::Uuid(id)]);
         let iterator = self
             .db
@@ -453,7 +453,7 @@ impl EdgeMetadataManager {
         outbound_id: Uuid,
         t: &'a models::Type,
         inbound_id: Uuid,
-    ) -> Result<Box<dyn Iterator<Item = Result<EdgeMetadataItem>> + 'a>> {
+    ) -> Result<Box<dyn Iterator<Item=Result<EdgeMetadataItem>> + 'a>> {
         let prefix = build_key(&[
             KeyComponent::Uuid(outbound_id),
             KeyComponent::Type(t),


### PR DESCRIPTION
Some minor cleanup to the rocksdb implementation:
* Use `impl Trait` / `dyn Trait` where possible
* Reduce duplicate code
* Various small improvements