### PR TITLE
Use associated types

### DIFF
--- a/bin/src/common_tests/lib.rs
+++ b/bin/src/common_tests/lib.rs
@@ -81,8 +81,10 @@ impl Drop for BatchDatastore {
     }
 }
 
-impl Datastore<BatchTransaction> for BatchDatastore {
-    fn transaction(&self) -> Result<BatchTransaction, Error> {
+impl Datastore for BatchDatastore {
+    type T = BatchTransaction;
+
+    fn transaction(&self) -> Result<Self::T, Error> {
         Ok(BatchTransaction::new(self.port))
     }
 }

--- a/bin/src/server/datastore.rs
+++ b/bin/src/server/datastore.rs
@@ -16,7 +16,9 @@ pub enum ProxyDatastore {
     Memory(MemoryDatastore),
 }
 
-impl Datastore<ProxyTransaction> for ProxyDatastore {
+impl Datastore for ProxyDatastore {
+    type T = ProxyTransaction;
+
     fn transaction(&self) -> Result<ProxyTransaction, Error> {
         match *self {
             ProxyDatastore::Rocksdb(ref r) => {

--- a/lib/src/memory/datastore.rs
+++ b/lib/src/memory/datastore.rs
@@ -267,8 +267,10 @@ impl MemoryDatastore {
     }
 }
 
-impl Datastore<MemoryTransaction> for MemoryDatastore {
-    fn transaction(&self) -> Result<MemoryTransaction> {
+impl Datastore for MemoryDatastore {
+    type T = MemoryTransaction;
+
+    fn transaction(&self) -> Result<Self::T> {
         Ok(MemoryTransaction {
             datastore: Arc::clone(&self.0),
         })

--- a/lib/src/rdb/datastore.rs
+++ b/lib/src/rdb/datastore.rs
@@ -88,8 +88,10 @@ impl RocksdbDatastore {
     }
 }
 
-impl Datastore<RocksdbTransaction> for RocksdbDatastore {
-    fn transaction(&self) -> Result<RocksdbTransaction> {
+impl Datastore for RocksdbDatastore {
+    type T = RocksdbTransaction;
+
+    fn transaction(&self) -> Result<Self::T> {
         RocksdbTransaction::new(self.db.clone())
     }
 }

--- a/lib/src/tests/edge.rs
+++ b/lib/src/tests/edge.rs
@@ -6,10 +6,7 @@ use models;
 use std::collections::HashSet;
 use uuid::Uuid;
 
-pub fn should_get_a_valid_edge<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_a_valid_edge<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
 
@@ -41,10 +38,7 @@ where
     assert!(e[0].created_datetime <= end_time);
 }
 
-pub fn should_not_get_an_invalid_edge<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_not_get_an_invalid_edge<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
 
@@ -69,10 +63,7 @@ where
     assert_eq!(e.len(), 0);
 }
 
-pub fn should_create_a_valid_edge<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_create_a_valid_edge<D: Datastore>(datastore: &mut D)
 {
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
     let trans = datastore.transaction().unwrap();
@@ -119,10 +110,7 @@ where
     assert_eq!(key, e[0].key);
 }
 
-pub fn should_not_create_an_invalid_edge<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_not_create_an_invalid_edge<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
@@ -134,10 +122,7 @@ where
     assert_eq!(result.unwrap(), false);
 }
 
-pub fn should_delete_a_valid_edge<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_delete_a_valid_edge<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_edge_type".to_string()).unwrap();
@@ -158,10 +143,7 @@ where
     assert_eq!(e.len(), 0);
 }
 
-pub fn should_not_delete_an_invalid_edge<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_not_delete_an_invalid_edge<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_edge_type".to_string()).unwrap();
@@ -175,10 +157,7 @@ where
         .unwrap();
 }
 
-pub fn should_get_an_edge_count<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_an_edge_count<D: Datastore>(datastore: &mut D)
 {
     let (outbound_id, _) = create_edges(datastore);
     let trans = datastore.transaction().unwrap();
@@ -189,10 +168,7 @@ where
     assert_eq!(count, 5);
 }
 
-pub fn should_get_an_edge_count_with_no_type<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_an_edge_count_with_no_type<D: Datastore>(datastore: &mut D)
 {
     let (outbound_id, _) = create_edges(datastore);
     let trans = datastore.transaction().unwrap();
@@ -202,10 +178,7 @@ where
     assert_eq!(count, 5);
 }
 
-pub fn should_get_an_edge_count_for_an_invalid_edge<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_an_edge_count_for_an_invalid_edge<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let t = models::Type::new("test_edge_type".to_string()).unwrap();
@@ -215,10 +188,7 @@ where
     assert_eq!(count, 0);
 }
 
-pub fn should_get_an_inbound_edge_count<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_an_inbound_edge_count<D: Datastore>(datastore: &mut D)
 {
     let (_, inbound_ids) = create_edges(datastore);
     let trans = datastore.transaction().unwrap();
@@ -228,10 +198,7 @@ where
     assert_eq!(count, 1);
 }
 
-pub fn should_get_an_edge_range<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_an_edge_range<D: Datastore>(datastore: &mut D)
 {
     let (outbound_id, start_time, end_time, _) = create_time_range_queryable_edges(datastore);
     let trans = datastore.transaction().unwrap();
@@ -242,10 +209,7 @@ where
     check_edge_range(&range, outbound_id, 5);
 }
 
-pub fn should_get_edges_with_no_type<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_edges_with_no_type<D: Datastore>(datastore: &mut D)
 {
     let (outbound_id, start_time, end_time, _) = create_time_range_queryable_edges(datastore);
     let trans = datastore.transaction().unwrap();
@@ -254,10 +218,7 @@ where
     check_edge_range(&range, outbound_id, 5);
 }
 
-pub fn should_get_no_edges_for_an_invalid_range<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_no_edges_for_an_invalid_range<D: Datastore>(datastore: &mut D)
 {
     let (outbound_id, start_time, end_time, _) = create_time_range_queryable_edges(datastore);
     let trans = datastore.transaction().unwrap();
@@ -268,10 +229,7 @@ where
     check_edge_range(&range, outbound_id, 0);
 }
 
-pub fn should_get_edges_with_no_high<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_edges_with_no_high<D: Datastore>(datastore: &mut D)
 {
     let (outbound_id, start_time, _, _) = create_time_range_queryable_edges(datastore);
     let trans = datastore.transaction().unwrap();
@@ -281,10 +239,7 @@ where
     check_edge_range(&range, outbound_id, 10);
 }
 
-pub fn should_get_edges_with_no_low<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_edges_with_no_low<D: Datastore>(datastore: &mut D)
 {
     let (outbound_id, _, end_time, _) = create_time_range_queryable_edges(datastore);
     let trans = datastore.transaction().unwrap();
@@ -294,10 +249,7 @@ where
     check_edge_range(&range, outbound_id, 10);
 }
 
-pub fn should_get_edges_with_no_time<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_edges_with_no_time<D: Datastore>(datastore: &mut D)
 {
     let (outbound_id, _, _, _) = create_time_range_queryable_edges(datastore);
     let trans = datastore.transaction().unwrap();
@@ -307,10 +259,7 @@ where
     check_edge_range(&range, outbound_id, 15);
 }
 
-pub fn should_get_no_edges_for_reversed_time<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_no_edges_for_reversed_time<D: Datastore>(datastore: &mut D)
 {
     let (outbound_id, start_time, end_time, _) = create_time_range_queryable_edges(datastore);
     let trans = datastore.transaction().unwrap();
@@ -321,10 +270,7 @@ where
     check_edge_range(&range, outbound_id, 0);
 }
 
-pub fn should_get_edges<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_edges<D: Datastore>(datastore: &mut D)
 {
     let (outbound_id, _, _, inbound_ids) = create_time_range_queryable_edges(datastore);
     let trans = datastore.transaction().unwrap();
@@ -342,17 +288,14 @@ where
     check_edge_range(&range, outbound_id, 5);
 }
 
-pub fn should_get_edges_piped<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_edges_piped<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
     let outbound_v = models::Vertex::new(vertex_t);
     trans.create_vertex(&outbound_v).unwrap();
 
-    let inbound_id = create_edge_from::<D, T>(&trans, outbound_v.id);
+    let inbound_id = create_edge_from(&trans, outbound_v.id);
 
     let query_1 = VertexQuery::Vertices {
         ids: vec![outbound_v.id],

--- a/lib/src/tests/metadata.rs
+++ b/lib/src/tests/metadata.rs
@@ -3,10 +3,7 @@ use serde_json::Value as JsonValue;
 use util::generate_random_secret;
 use uuid::Uuid;
 
-pub fn should_handle_vertex_metadata<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_handle_vertex_metadata<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let t = Type::new("test_edge_type".to_string()).unwrap();
@@ -39,10 +36,7 @@ where
     assert_eq!(result.len(), 0);
 }
 
-pub fn should_not_set_invalid_vertex_metadata<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_not_set_invalid_vertex_metadata<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let q = VertexQuery::Vertices {
@@ -53,10 +47,7 @@ where
     assert_eq!(result.len(), 0);
 }
 
-pub fn should_not_delete_invalid_vertex_metadata<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_not_delete_invalid_vertex_metadata<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let q = VertexQuery::Vertices {
@@ -71,10 +62,7 @@ where
     trans.delete_vertex_metadata(&q, "foo").unwrap();
 }
 
-pub fn should_handle_edge_metadata<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_handle_edge_metadata<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = Type::new("test_edge_type".to_string()).unwrap();
@@ -115,10 +103,7 @@ where
     assert_eq!(result.len(), 0);
 }
 
-pub fn should_not_set_invalid_edge_metadata<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_not_set_invalid_edge_metadata<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let q = EdgeQuery::Edges {
@@ -133,10 +118,7 @@ where
     assert_eq!(result.len(), 0);
 }
 
-pub fn should_not_delete_invalid_edge_metadata<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_not_delete_invalid_edge_metadata<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let q = EdgeQuery::Edges {

--- a/lib/src/tests/util.rs
+++ b/lib/src/tests/util.rs
@@ -4,10 +4,7 @@ use chrono::DateTime;
 use models;
 use uuid::Uuid;
 
-pub fn create_edge_from<D, T>(trans: &T, outbound_id: Uuid) -> Uuid
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn create_edge_from<T: Transaction>(trans: &T, outbound_id: Uuid) -> Uuid
 {
     let inbound_vertex_t = models::Type::new("test_inbound_vertex_type".to_string()).unwrap();
     let inbound_v = models::Vertex::new(inbound_vertex_t);
@@ -18,57 +15,51 @@ where
     inbound_v.id
 }
 
-pub fn create_edges<D, T>(datastore: &mut D) -> (Uuid, [Uuid; 5])
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn create_edges<D: Datastore>(datastore: &mut D) -> (Uuid, [Uuid; 5])
 {
     let trans = datastore.transaction().unwrap();
     let outbound_vertex_t = models::Type::new("test_outbound_vertex_type".to_string()).unwrap();
     let outbound_v = models::Vertex::new(outbound_vertex_t);
     trans.create_vertex(&outbound_v).unwrap();
     let inbound_ids: [Uuid; 5] = [
-        create_edge_from::<D, T>(&trans, outbound_v.id),
-        create_edge_from::<D, T>(&trans, outbound_v.id),
-        create_edge_from::<D, T>(&trans, outbound_v.id),
-        create_edge_from::<D, T>(&trans, outbound_v.id),
-        create_edge_from::<D, T>(&trans, outbound_v.id),
+        create_edge_from(&trans, outbound_v.id),
+        create_edge_from(&trans, outbound_v.id),
+        create_edge_from(&trans, outbound_v.id),
+        create_edge_from(&trans, outbound_v.id),
+        create_edge_from(&trans, outbound_v.id),
     ];
 
     (outbound_v.id, inbound_ids)
 }
 
-pub fn create_time_range_queryable_edges<D, T>(datastore: &mut D) -> (Uuid, DateTime<Utc>, DateTime<Utc>, [Uuid; 5])
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn create_time_range_queryable_edges<D: Datastore>(datastore: &mut D) -> (Uuid, DateTime<Utc>, DateTime<Utc>, [Uuid; 5])
 {
     let trans = datastore.transaction().unwrap();
     let outbound_vertex_t = models::Type::new("test_outbound_vertex_type".to_string()).unwrap();
     let outbound_v = models::Vertex::new(outbound_vertex_t);
     trans.create_vertex(&outbound_v).unwrap();
 
-    create_edge_from::<D, T>(&trans, outbound_v.id);
-    create_edge_from::<D, T>(&trans, outbound_v.id);
-    create_edge_from::<D, T>(&trans, outbound_v.id);
-    create_edge_from::<D, T>(&trans, outbound_v.id);
-    create_edge_from::<D, T>(&trans, outbound_v.id);
+    create_edge_from(&trans, outbound_v.id);
+    create_edge_from(&trans, outbound_v.id);
+    create_edge_from(&trans, outbound_v.id);
+    create_edge_from(&trans, outbound_v.id);
+    create_edge_from(&trans, outbound_v.id);
 
     let start_time = Utc::now();
     let inbound_ids = [
-        create_edge_from::<D, T>(&trans, outbound_v.id),
-        create_edge_from::<D, T>(&trans, outbound_v.id),
-        create_edge_from::<D, T>(&trans, outbound_v.id),
-        create_edge_from::<D, T>(&trans, outbound_v.id),
-        create_edge_from::<D, T>(&trans, outbound_v.id),
+        create_edge_from(&trans, outbound_v.id),
+        create_edge_from(&trans, outbound_v.id),
+        create_edge_from(&trans, outbound_v.id),
+        create_edge_from(&trans, outbound_v.id),
+        create_edge_from(&trans, outbound_v.id),
     ];
     let end_time = Utc::now();
 
-    create_edge_from::<D, T>(&trans, outbound_v.id);
-    create_edge_from::<D, T>(&trans, outbound_v.id);
-    create_edge_from::<D, T>(&trans, outbound_v.id);
-    create_edge_from::<D, T>(&trans, outbound_v.id);
-    create_edge_from::<D, T>(&trans, outbound_v.id);
+    create_edge_from(&trans, outbound_v.id);
+    create_edge_from(&trans, outbound_v.id);
+    create_edge_from(&trans, outbound_v.id);
+    create_edge_from(&trans, outbound_v.id);
+    create_edge_from(&trans, outbound_v.id);
 
     (outbound_v.id, start_time, end_time, inbound_ids)
 }

--- a/lib/src/tests/vertex.rs
+++ b/lib/src/tests/vertex.rs
@@ -5,20 +5,14 @@ use std::collections::HashSet;
 use std::u32;
 use uuid::Uuid;
 
-pub fn should_create_vertex_from_type<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_create_vertex_from_type<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let t = models::Type::new("test_vertex_type".to_string()).unwrap();
     trans.create_vertex_from_type(t).unwrap();
 }
 
-pub fn should_get_all_vertices<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_all_vertices<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let mut inserted_ids = create_vertices(&trans);
@@ -45,10 +39,7 @@ where
     }
 }
 
-pub fn should_get_all_vertices_with_zero_limit<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_all_vertices_with_zero_limit<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     create_vertices(&trans);
@@ -63,10 +54,7 @@ where
     assert_eq!(range.len(), 0);
 }
 
-pub fn should_get_all_vertices_out_of_range<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_all_vertices_out_of_range<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     create_vertices(&trans);
@@ -81,10 +69,7 @@ where
     assert_eq!(range.len(), 0);
 }
 
-pub fn should_get_single_vertices<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_single_vertices<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
@@ -98,10 +83,7 @@ where
     assert_eq!(range[0].t.0, "test_vertex_type");
 }
 
-pub fn should_get_single_vertices_nonexisting<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_single_vertices_nonexisting<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
@@ -115,10 +97,7 @@ where
     assert_eq!(range.len(), 0);
 }
 
-pub fn should_get_vertices<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_vertices<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let mut inserted_ids = create_vertices(&trans);
@@ -144,17 +123,14 @@ where
     }
 }
 
-pub fn should_get_vertices_piped<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_vertices_piped<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();
 
     let v = models::Vertex::new(vertex_t);
     trans.create_vertex(&v).unwrap();
-    let inserted_id_2 = create_edge_from::<D, T>(&trans, v.id);
+    let inserted_id_2 = create_edge_from(&trans, v.id);
 
     // This query should get `inserted_id_2`
     let query_1 = VertexQuery::Vertices { ids: vec![v.id] }
@@ -183,10 +159,7 @@ where
     assert_eq!(range[0], v);
 }
 
-pub fn should_delete_a_valid_vertex<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_delete_a_valid_vertex<D: Datastore>(datastore: &mut D)
 {
     let (outbound_id, _) = create_edges(datastore);
     let trans = datastore.transaction().unwrap();
@@ -201,10 +174,7 @@ where
     assert_eq!(count, 0);
 }
 
-pub fn should_not_delete_an_invalid_vertex<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_not_delete_an_invalid_vertex<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     trans
@@ -214,10 +184,7 @@ where
         .unwrap();
 }
 
-pub fn should_get_a_vertex_count<D, T>(datastore: &mut D)
-where
-    D: Datastore<T>,
-    T: Transaction,
+pub fn should_get_a_vertex_count<D: Datastore>(datastore: &mut D)
 {
     let trans = datastore.transaction().unwrap();
     let vertex_t = models::Type::new("test_vertex_type".to_string()).unwrap();

--- a/lib/src/traits.rs
+++ b/lib/src/traits.rs
@@ -11,9 +11,11 @@ use uuid::Uuid;
 /// # Errors
 /// All methods may return an error if something unexpected happens - e.g.
 /// if there was a problem connecting to the underlying database.
-pub trait Datastore<T: Transaction> {
+pub trait Datastore {
+    type T: Transaction;
+
     /// Creates a new transaction.
-    fn transaction(&self) -> Result<T>;
+    fn transaction(&self) -> Result<Self::T>;
 }
 
 /// Specifies a transaction implementation, which are returned by datastores.


### PR DESCRIPTION
Use associated types rather than generics on the `Datastore` trait for ergonomics.