### PR TITLE
Fixed limit=0 bug for in-memory datastore

### DIFF
--- a/lib/src/memory/datastore.rs
+++ b/lib/src/memory/datastore.rs
@@ -113,6 +113,10 @@ impl InternalMemoryDatastore {
                 let vertex_values = self.get_vertex_values_by_query(&*vertex_query)?;
                 let mut results = Vec::new();
 
+                if limit == 0 {
+                    return Ok(results);
+                }
+
                 match converter {
                     models::EdgeDirection::Outbound => {
                         for (id, _) in vertex_values {


### PR DESCRIPTION
Fixed a bug where, for the in-memory datastore, the limit would not be applied to edge queries when the limit=0
