### PR TITLE
Serdeless lib

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -27,9 +27,7 @@ path = "src/common/lib.rs"
 
 [dependencies]
 error-chain = "~0.12.0"
-serde = "^1.0.79"
 serde_json = "^1.0.31"
-serde_derive = "^1.0.79"
 libc = "0.2.43"
 rand = "~0.5.5"
 regex = "^1.0.5"
@@ -42,8 +40,8 @@ tokio-core = "0.1.17"
 tokio-io = "0.1.10"
 futures-cpupool = "0.1.8"
 num_cpus = "1.8.0"
-chrono = { version = "0.4.6", features = ["serde"] }
-uuid = { version = "~0.7.1", features = ["serde", "v4"] }
+chrono = "0.4.6"
+uuid = "~0.7.1"
 
 [dependencies.indradb-lib]
 path = "../lib"

--- a/bin/src/common/lib.rs
+++ b/bin/src/common/lib.rs
@@ -12,7 +12,6 @@ extern crate futures_cpupool;
 extern crate lazy_static;
 extern crate libc;
 extern crate regex;
-extern crate serde;
 extern crate serde_json;
 extern crate tokio_core;
 extern crate tokio_io;

--- a/bin/src/server/main.rs
+++ b/bin/src/server/main.rs
@@ -8,7 +8,6 @@ extern crate indradb;
 extern crate libc;
 extern crate num_cpus;
 extern crate regex;
-extern crate serde;
 extern crate serde_json;
 extern crate uuid;
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,24 +18,21 @@ path = "src/lib.rs"
 
 [features]
 default = []
-rocksdb-datastore = ["rocksdb", "bincode"]
+rocksdb-datastore = ["rocksdb"]
 test-suite = []
 bench-suite = []
 
 [dependencies]
 error-chain = "~0.12.0"
 rust-crypto = "~0.2.36"
-serde = "^1.0.79"
 serde_json = "^1.0.31"
-serde_derive = "^1.0.79"
 libc = "0.2.43"
 rand = "~0.5.5"
 regex = "^1.0.5"
 lazy_static = "^1.1.0"
 byteorder = "^1.2.6"
-chrono = { version = "0.4.6", features = ["serde"] }
-uuid = { version = "~0.7.1", features = ["serde", "v1"] }
+chrono = "0.4.6"
+uuid = { version = "~0.7.1", features = ["v1"] }
 
 # Rocksdb dependencies
 rocksdb = { version = "0.10.1", optional = true }
-bincode = { version = "0.9.2", optional = true }

--- a/lib/src/benches/benches.rs
+++ b/lib/src/benches/benches.rs
@@ -1,4 +1,4 @@
-use models::{EdgeDirection, EdgeKey, Type, Vertex, SpecificVertexQuery, SpecificEdgeQuery};
+use models::{EdgeDirection, EdgeKey, SpecificEdgeQuery, SpecificVertexQuery, Type, Vertex};
 use test::Bencher;
 use traits::{Datastore, Transaction};
 

--- a/lib/src/errors.rs
+++ b/lib/src/errors.rs
@@ -1,6 +1,4 @@
 #[cfg(feature = "rocksdb-datastore")]
-use bincode::Error as BincodeError;
-#[cfg(feature = "rocksdb-datastore")]
 use rocksdb::Error as RocksDbError;
 use serde_json::Error as JsonError;
 
@@ -12,7 +10,6 @@ error_chain!{
     foreign_links {
         Json(JsonError);
         RocksDb(RocksDbError) #[cfg(feature = "rocksdb-datastore")];
-        Bincode(BincodeError) #[cfg(feature = "rocksdb-datastore")];
     }
 }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -24,14 +24,9 @@ extern crate lazy_static;
 extern crate libc;
 extern crate rand;
 extern crate regex;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
 extern crate serde_json;
 extern crate uuid;
 
-#[cfg(feature = "rocksdb-datastore")]
-extern crate bincode;
 #[cfg(feature = "rocksdb-datastore")]
 extern crate rocksdb;
 

--- a/lib/src/models/bulk_insert.rs
+++ b/lib/src/models/bulk_insert.rs
@@ -3,7 +3,7 @@ use super::vertices::Vertex;
 use serde_json::Value as JsonValue;
 use uuid::Uuid;
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum BulkInsertItem {
     Vertex(Vertex),
     Edge(EdgeKey),

--- a/lib/src/models/edges.rs
+++ b/lib/src/models/edges.rs
@@ -4,13 +4,12 @@ use chrono::DateTime;
 use uuid::Uuid;
 
 /// Represents a uniquely identifiable key to an edge.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct EdgeKey {
     /// The id of the outbound vertex.
     pub outbound_id: Uuid,
 
     /// The type of the edge.
-    #[serde(rename = "type")]
     pub t: Type,
 
     /// The id of the inbound vertex.
@@ -39,7 +38,7 @@ impl EdgeKey {
 /// Edges are how you would represent a verb or a relationship in the
 /// datastore. An example might be "liked" or "reviewed". Edges are typed
 /// and directed.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
 pub struct Edge {
     /// The key to the edge.
     pub key: EdgeKey,

--- a/lib/src/models/properties.rs
+++ b/lib/src/models/properties.rs
@@ -3,7 +3,7 @@ use serde_json::Value as JsonValue;
 use uuid::Uuid;
 
 /// Represents a vertex property.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct VertexProperty {
     /// The id of the vertex
     pub id: Uuid,
@@ -25,7 +25,7 @@ impl VertexProperty {
 }
 
 /// Represents an edge property.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct EdgeProperty {
     /// The key to the edge.
     pub key: EdgeKey,

--- a/lib/src/models/queries.rs
+++ b/lib/src/models/queries.rs
@@ -14,11 +14,9 @@ use uuid::Uuid;
 /// query to an edge query. `EdgeDirection`s are used to specify which
 /// end of things you want to pipe - either the outbound items or the inbound
 /// items.
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Hash, Copy)]
+#[derive(Eq, PartialEq, Clone, Debug, Hash, Copy)]
 pub enum EdgeDirection {
-    #[serde(rename = "outbound")]
     Outbound,
-    #[serde(rename = "inbound")]
     Inbound,
 }
 

--- a/lib/src/models/types.rs
+++ b/lib/src/models/types.rs
@@ -10,7 +10,7 @@ lazy_static! {
 ///
 /// Types must be less than 256 characters long, and can only contain letters,
 /// numbers, dashes and underscores.
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Hash, Ord, PartialOrd)]
+#[derive(Eq, PartialEq, Clone, Debug, Hash, Ord, PartialOrd)]
 pub struct Type(pub String);
 
 impl Type {
@@ -33,6 +33,10 @@ impl Type {
         } else {
             Ok(Type(s))
         }
+    }
+
+    pub unsafe fn new_unchecked<S: Into<String>>(s: S) -> Self {
+        Type(s.into())
     }
 }
 

--- a/lib/src/models/vertices.rs
+++ b/lib/src/models/vertices.rs
@@ -6,13 +6,12 @@ use uuid::Uuid;
 ///
 /// Vertices are how you would represent nouns in the datastore. An example
 /// might be a user, or a movie. All vertices have a unique ID and a type.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
 pub struct Vertex {
     /// The id of the vertex.
     pub id: Uuid,
 
     /// The type of the vertex.
-    #[serde(rename = "type")]
     pub t: Type,
 }
 

--- a/lib/src/rdb/bytes.rs
+++ b/lib/src/rdb/bytes.rs
@@ -20,36 +20,36 @@ lazy_static! {
             .unwrap();
 }
 
-pub enum KeyComponent<'a> {
+pub enum Component<'a> {
     Uuid(Uuid),
     UnsizedString(&'a str),
     Type(&'a models::Type),
     DateTime(DateTime<Utc>),
 }
 
-impl<'a> KeyComponent<'a> {
+impl<'a> Component<'a> {
     fn len(&self) -> usize {
         match *self {
-            KeyComponent::Uuid(_) => 16,
-            KeyComponent::UnsizedString(s) => s.len(),
-            KeyComponent::Type(t) => t.0.len() + 1,
-            KeyComponent::DateTime(_) => 8,
+            Component::Uuid(_) => 16,
+            Component::UnsizedString(s) => s.len(),
+            Component::Type(t) => t.0.len() + 1,
+            Component::DateTime(_) => 8,
         }
     }
 
     fn write(&self, cursor: &mut Cursor<Vec<u8>>) -> Result<(), IoError> {
         match *self {
-            KeyComponent::Uuid(uuid) => {
+            Component::Uuid(uuid) => {
                 cursor.write_all(uuid.as_bytes())?;
             }
-            KeyComponent::UnsizedString(s) => {
+            Component::UnsizedString(s) => {
                 cursor.write_all(s.as_bytes())?;
             }
-            KeyComponent::Type(t) => {
+            Component::Type(t) => {
                 cursor.write_all(&[t.0.len() as u8])?;
                 cursor.write_all(t.0.as_bytes())?;
             }
-            KeyComponent::DateTime(datetime) => {
+            Component::DateTime(datetime) => {
                 let time_to_end = nanos_since_epoch(&MAX_DATETIME) - nanos_since_epoch(&datetime);
                 cursor.write_u64::<BigEndian>(time_to_end)?;
             }
@@ -59,26 +59,26 @@ impl<'a> KeyComponent<'a> {
     }
 }
 
-pub fn build_key(components: &[KeyComponent]) -> Box<[u8]> {
+pub fn build(components: &[Component]) -> Box<[u8]> {
     let len = components.iter().fold(0, |len, component| len + component.len());
     let mut cursor: Cursor<Vec<u8>> = Cursor::new(Vec::with_capacity(len));
 
     for component in components {
         if let Err(err) = component.write(&mut cursor) {
-            panic!("Could not build key: {}", err);
+            panic!("Could not write bytes: {}", err);
         }
     }
 
     cursor.into_inner().into_boxed_slice()
 }
 
-pub fn read_uuid(cursor: &mut Cursor<Box<[u8]>>) -> Uuid {
+pub fn read_uuid<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Uuid {
     let mut buf: [u8; 16] = [0; 16];
     cursor.read_exact(&mut buf).unwrap();
     Uuid::from_slice(&buf).unwrap()
 }
 
-pub fn read_type(cursor: &mut Cursor<Box<[u8]>>) -> models::Type {
+pub fn read_type<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> models::Type {
     let t_len = {
         let mut buf: [u8; 1] = [0; 1];
         cursor.read_exact(&mut buf).unwrap();
@@ -87,17 +87,20 @@ pub fn read_type(cursor: &mut Cursor<Box<[u8]>>) -> models::Type {
 
     let mut buf = vec![0u8; t_len];
     cursor.read_exact(&mut buf).unwrap();
-    let s = str::from_utf8(&buf).unwrap().to_string();
-    models::Type::new(s).unwrap()
+    
+    unsafe {
+        let s = str::from_utf8_unchecked(&buf).to_string();
+        models::Type::new_unchecked(s)
+    }
 }
 
-pub fn read_unsized_string(cursor: &mut Cursor<Box<[u8]>>) -> String {
+pub fn read_unsized_string<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> String {
     let mut buf = String::new();
     cursor.read_to_string(&mut buf).unwrap();
     buf
 }
 
-pub fn read_datetime(cursor: &mut Cursor<Box<[u8]>>) -> DateTime<Utc> {
+pub fn read_datetime<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> DateTime<Utc> {
     let time_to_end = cursor.read_u64::<BigEndian>().unwrap();
     assert!(time_to_end <= i64::MAX as u64);
     *MAX_DATETIME - Duration::nanoseconds(time_to_end as i64)

--- a/lib/src/rdb/bytes.rs
+++ b/lib/src/rdb/bytes.rs
@@ -87,7 +87,7 @@ pub fn read_type<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> models::Type {
 
     let mut buf = vec![0u8; t_len];
     cursor.read_exact(&mut buf).unwrap();
-    
+
     unsafe {
         let s = str::from_utf8_unchecked(&buf).to_string();
         models::Type::new_unchecked(s)

--- a/lib/src/rdb/managers.rs
+++ b/lib/src/rdb/managers.rs
@@ -7,10 +7,10 @@ use rocksdb::{ColumnFamily, DBIterator, Direction, IteratorMode, WriteBatch, DB}
 use serde_json;
 use serde_json::Value as JsonValue;
 use std::io::Cursor;
+use std::ops::Deref;
 use std::sync::Arc;
 use std::u8;
 use uuid::Uuid;
-use std::ops::Deref;
 
 pub type OwnedPropertyItem = ((Uuid, String), JsonValue);
 pub type VertexItem = (Uuid, models::Type);
@@ -50,7 +50,7 @@ impl VertexManager {
             Some(value_bytes) => {
                 let mut cursor = Cursor::new(value_bytes.deref());
                 Ok(Some(read_type(&mut cursor)))
-            },
+            }
             None => Ok(None),
         }
     }
@@ -161,7 +161,7 @@ impl EdgeManager {
             Some(value_bytes) => {
                 let mut cursor = Cursor::new(value_bytes.deref());
                 Ok(Some(read_datetime(&mut cursor)))
-            },
+            }
             None => Ok(None),
         }
     }
@@ -274,11 +274,7 @@ impl EdgeRangeManager {
             Some(t) => {
                 let high = high.unwrap_or_else(|| *MAX_DATETIME);
                 let prefix = build(&[Component::Uuid(id), Component::Type(t)]);
-                let low_key = build(&[
-                    Component::Uuid(id),
-                    Component::Type(t),
-                    Component::DateTime(high),
-                ]);
+                let low_key = build(&[Component::Uuid(id), Component::Type(t), Component::DateTime(high)]);
                 let iterator = self
                     .db
                     .iterator_cf(self.cf, IteratorMode::From(&low_key, Direction::Forward))?;

--- a/lib/src/rdb/mod.rs
+++ b/lib/src/rdb/mod.rs
@@ -1,7 +1,7 @@
 //! The rocksdb datastore implementation.
 
+mod bytes;
 mod datastore;
-mod keys;
 mod managers;
 
 #[cfg(feature = "test-suite")]


### PR DESCRIPTION
With the removal of the HTTP API, serde is no longer needed. This removes serde, and changes the RocksDB implementation to use a custom serialization scheme.