### PR TITLE
Manually implement hash

### DIFF
--- a/lib/src/models/vertices.rs
+++ b/lib/src/models/vertices.rs
@@ -1,12 +1,13 @@
 use super::types::Type;
 use crate::util::generate_uuid_v1;
+use std::hash::{Hash, Hasher};
 use uuid::Uuid;
 
 /// A vertex.
 ///
 /// Vertices are how you would represent nouns in the datastore. An example
 /// might be a user, or a movie. All vertices have a unique ID and a type.
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug)]
 pub struct Vertex {
     /// The id of the vertex.
     pub id: Uuid,
@@ -42,6 +43,12 @@ impl Vertex {
 impl PartialEq for Vertex {
     fn eq(&self, other: &Vertex) -> bool {
         self.id == other.id
+    }
+}
+
+impl Hash for Vertex {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
     }
 }
 


### PR DESCRIPTION
The autoderivation of Hash is problematic because PartialEq is manually derived: https://rust-lang.github.io/rust-clippy/master/index.html#derive_hash_xor_eq

This fixes the issue.