### PR TITLE
Support fetching of all properties for a given vertex or edge

### DIFF
--- a/bin/indradb.capnp
+++ b/bin/indradb.capnp
@@ -81,9 +81,19 @@ struct VertexProperty {
     value @1 :Json;
 }
 
+struct VertexProperties {
+    vertex @0 :Vertex;
+    props @1 :List(Property);
+}
+
 struct EdgeProperty {
     key @0 :EdgeKey;
     value @1 :Json;
+}
+
+struct EdgeProperties {
+    edge @0 :Edge;
+    props @1 :List(Property);
 }
 
 struct BulkInsertItem {
@@ -217,4 +227,17 @@ interface Transaction {
     # * `q` - The query to run.
     # * `name` - The property name.
     deleteEdgeProperties @14 (q :EdgePropertyQuery) -> (result :Void);
+
+    # Gets vertexes and all properties for each vertex.
+    #
+    # Arguments
+    # * `q` - The query to run.
+    getAllVertexProperties @15 (q :VertexQuery) -> (result :List(VertexProperties));
+
+    # Gets edges and all properties for each edge.
+    #
+    # Arguments
+    # * `q` - The query to run.
+    getAllEdgeProperties @16 (q :EdgeQuery) -> (result :List(EdgeProperties));
+
 }

--- a/bin/src/common/client_datastore.rs
+++ b/bin/src/common/client_datastore.rs
@@ -259,6 +259,23 @@ impl indradb::Transaction for ClientTransaction {
         })
     }
 
+    fn get_all_vertex_properties<Q: Into<indradb::VertexQuery>>(&self, q: Q) -> Result<Vec<indradb::VertexProperties>, indradb::Error> {
+
+        self.execute(move |trans| {
+            let mut req = trans.get_all_vertex_properties_request();
+            converters::from_vertex_query(&q.into(), req.get().init_q());
+
+            let f = req.send().promise.and_then(move |res| {
+                let list = res.get()?.get_result()?;
+                let list: Result<Vec<indradb::VertexProperties>, CapnpError> =
+                    list.into_iter().map(|reader| converters::to_vertex_properties(&reader)).collect();
+                list
+            });
+
+            Box::new(f)
+        })
+    }
+
     fn set_vertex_properties(&self, q: indradb::VertexPropertyQuery, value: &JsonValue) -> Result<(), indradb::Error> {
         self.execute(move |trans| {
             let mut req = trans.set_vertex_properties_request();
@@ -299,6 +316,23 @@ impl indradb::Transaction for ClientTransaction {
                     .into_iter()
                     .map(|reader| converters::to_edge_property(&reader))
                     .collect();
+                list
+            });
+
+            Box::new(f)
+        })
+    }
+
+    fn get_all_edge_properties<Q: Into<indradb::EdgeQuery>>(&self, q: Q) -> Result<Vec<indradb::EdgeProperties>, indradb::Error> {
+
+        self.execute(move |trans| {
+            let mut req = trans.get_all_edge_properties_request();
+            converters::from_edge_query(&q.into(), req.get().init_q());
+
+            let f = req.send().promise.and_then(move |res| {
+                let list = res.get()?.get_result()?;
+                let list: Result<Vec<indradb::EdgeProperties>, CapnpError> =
+                    list.into_iter().map(|reader| converters::to_edge_properties(&reader)).collect();
                 list
             });
 

--- a/bin/src/common/client_datastore.rs
+++ b/bin/src/common/client_datastore.rs
@@ -259,16 +259,20 @@ impl indradb::Transaction for ClientTransaction {
         })
     }
 
-    fn get_all_vertex_properties<Q: Into<indradb::VertexQuery>>(&self, q: Q) -> Result<Vec<indradb::VertexProperties>, indradb::Error> {
-
+    fn get_all_vertex_properties<Q: Into<indradb::VertexQuery>>(
+        &self,
+        q: Q,
+    ) -> Result<Vec<indradb::VertexProperties>, indradb::Error> {
         self.execute(move |trans| {
             let mut req = trans.get_all_vertex_properties_request();
             converters::from_vertex_query(&q.into(), req.get().init_q());
 
             let f = req.send().promise.and_then(move |res| {
                 let list = res.get()?.get_result()?;
-                let list: Result<Vec<indradb::VertexProperties>, CapnpError> =
-                    list.into_iter().map(|reader| converters::to_vertex_properties(&reader)).collect();
+                let list: Result<Vec<indradb::VertexProperties>, CapnpError> = list
+                    .into_iter()
+                    .map(|reader| converters::to_vertex_properties(&reader))
+                    .collect();
                 list
             });
 
@@ -323,16 +327,20 @@ impl indradb::Transaction for ClientTransaction {
         })
     }
 
-    fn get_all_edge_properties<Q: Into<indradb::EdgeQuery>>(&self, q: Q) -> Result<Vec<indradb::EdgeProperties>, indradb::Error> {
-
+    fn get_all_edge_properties<Q: Into<indradb::EdgeQuery>>(
+        &self,
+        q: Q,
+    ) -> Result<Vec<indradb::EdgeProperties>, indradb::Error> {
         self.execute(move |trans| {
             let mut req = trans.get_all_edge_properties_request();
             converters::from_edge_query(&q.into(), req.get().init_q());
 
             let f = req.send().promise.and_then(move |res| {
                 let list = res.get()?.get_result()?;
-                let list: Result<Vec<indradb::EdgeProperties>, CapnpError> =
-                    list.into_iter().map(|reader| converters::to_edge_properties(&reader)).collect();
+                let list: Result<Vec<indradb::EdgeProperties>, CapnpError> = list
+                    .into_iter()
+                    .map(|reader| converters::to_edge_properties(&reader))
+                    .collect();
                 list
             });
 

--- a/bin/src/common/converters.rs
+++ b/bin/src/common/converters.rs
@@ -83,11 +83,8 @@ pub fn to_vertex_properties<'a>(
     reader: &autogen::vertex_properties::Reader<'a>,
 ) -> Result<indradb::VertexProperties, CapnpError> {
     let vertex = map_capnp_err(to_vertex(&reader.get_vertex()?))?;
-    let named_props: Result<Vec<indradb::NamedProperty>, CapnpError> = reader
-        .get_props()?
-        .into_iter()
-        .map(to_named_property)
-        .collect();
+    let named_props: Result<Vec<indradb::NamedProperty>, CapnpError> =
+        reader.get_props()?.into_iter().map(to_named_property).collect();
     Ok(indradb::VertexProperties::new(vertex, named_props?))
 }
 
@@ -96,9 +93,7 @@ pub fn from_named_property<'a>(property: &indradb::NamedProperty, mut builder: a
     builder.set_value(&property.value.to_string());
 }
 
-pub fn to_named_property<'a>(
-    reader: autogen::property::Reader<'a>,
-) -> Result<indradb::NamedProperty, CapnpError> {
+pub fn to_named_property<'a>(reader: autogen::property::Reader<'a>) -> Result<indradb::NamedProperty, CapnpError> {
     let name = map_capnp_err(reader.get_name())?.to_string();
     let value = map_capnp_err(serde_json::from_str(reader.get_value()?))?;
     Ok(indradb::NamedProperty::new(name, value))
@@ -119,11 +114,8 @@ pub fn to_edge_properties<'a>(
     reader: &autogen::edge_properties::Reader<'a>,
 ) -> Result<indradb::EdgeProperties, CapnpError> {
     let edge = map_capnp_err(to_edge(&reader.get_edge()?))?;
-    let named_props: Result<Vec<indradb::NamedProperty>, CapnpError> = reader
-        .get_props()?
-        .into_iter()
-        .map(to_named_property)
-        .collect();
+    let named_props: Result<Vec<indradb::NamedProperty>, CapnpError> =
+        reader.get_props()?.into_iter().map(to_named_property).collect();
     Ok(indradb::EdgeProperties::new(edge, named_props?))
 }
 

--- a/bin/src/common/converters.rs
+++ b/bin/src/common/converters.rs
@@ -68,6 +68,65 @@ pub fn to_vertex_property<'a>(
     Ok(indradb::VertexProperty::new(id, value))
 }
 
+pub fn from_vertex_properties<'a>(
+    properties: &indradb::VertexProperties,
+    builder: &mut autogen::vertex_properties::Builder<'a>,
+) {
+    from_vertex(&properties.vertex, builder.reborrow().init_vertex());
+    let mut props_builder = builder.reborrow().init_props(properties.props.len() as u32);
+    for (i, prop) in properties.props.iter().enumerate() {
+        from_named_property(prop, props_builder.reborrow().get(i as u32));
+    }
+}
+
+pub fn to_vertex_properties<'a>(
+    reader: &autogen::vertex_properties::Reader<'a>,
+) -> Result<indradb::VertexProperties, CapnpError> {
+    let vertex = map_capnp_err(to_vertex(&reader.get_vertex()?))?;
+    let named_props: Result<Vec<indradb::NamedProperty>, CapnpError> = reader
+        .get_props()?
+        .into_iter()
+        .map(to_named_property)
+        .collect();
+    Ok(indradb::VertexProperties::new(vertex, named_props?))
+}
+
+pub fn from_named_property<'a>(property: &indradb::NamedProperty, mut builder: autogen::property::Builder<'a>) {
+    builder.set_name(&property.name);
+    builder.set_value(&property.value.to_string());
+}
+
+pub fn to_named_property<'a>(
+    reader: autogen::property::Reader<'a>,
+) -> Result<indradb::NamedProperty, CapnpError> {
+    let name = map_capnp_err(reader.get_name())?.to_string();
+    let value = map_capnp_err(serde_json::from_str(reader.get_value()?))?;
+    Ok(indradb::NamedProperty::new(name, value))
+}
+
+pub fn from_edge_properties<'a>(
+    properties: &indradb::EdgeProperties,
+    builder: &mut autogen::edge_properties::Builder<'a>,
+) {
+    from_edge(&properties.edge, builder.reborrow().init_edge()).unwrap();
+    let mut props_builder = builder.reborrow().init_props(properties.props.len() as u32);
+    for (i, prop) in properties.props.iter().enumerate() {
+        from_named_property(prop, props_builder.reborrow().get(i as u32));
+    }
+}
+
+pub fn to_edge_properties<'a>(
+    reader: &autogen::edge_properties::Reader<'a>,
+) -> Result<indradb::EdgeProperties, CapnpError> {
+    let edge = map_capnp_err(to_edge(&reader.get_edge()?))?;
+    let named_props: Result<Vec<indradb::NamedProperty>, CapnpError> = reader
+        .get_props()?
+        .into_iter()
+        .map(to_named_property)
+        .collect();
+    Ok(indradb::EdgeProperties::new(edge, named_props?))
+}
+
 pub fn from_edge_property<'a>(property: &indradb::EdgeProperty, mut builder: autogen::edge_property::Builder<'a>) {
     builder.set_value(&property.value.to_string());
     from_edge_key(&property.key, builder.init_key());

--- a/bin/src/common/server.rs
+++ b/bin/src/common/server.rs
@@ -10,9 +10,8 @@ use futures::{Future, Stream};
 use futures_cpupool::CpuPool;
 use indradb;
 use indradb::{
-    Datastore as IndraDbDatastore, Edge, EdgeProperty, MemoryDatastore, RocksdbDatastore,
-    Transaction as IndraDbTransaction, Type, Vertex, VertexProperty,
-    VertexProperties, EdgeProperties,
+    Datastore as IndraDbDatastore, Edge, EdgeProperties, EdgeProperty, MemoryDatastore, RocksdbDatastore,
+    Transaction as IndraDbTransaction, Type, Vertex, VertexProperties, VertexProperty,
 };
 use serde_json;
 use std::env;
@@ -345,7 +344,9 @@ impl<T: IndraDbTransaction + Send + Sync + 'static> autogen::transaction::Server
 
         let f = self
             .pool
-            .spawn_fn(move || -> Result<Vec<VertexProperties>, CapnpError> { converters::map_capnp_err(trans.get_all_vertex_properties(q)) })
+            .spawn_fn(move || -> Result<Vec<VertexProperties>, CapnpError> {
+                converters::map_capnp_err(trans.get_all_vertex_properties(q))
+            })
             .and_then(move |vertex_props| -> Result<(), CapnpError> {
                 let mut res = res.get().init_result(vertex_props.len() as u32);
 
@@ -445,7 +446,9 @@ impl<T: IndraDbTransaction + Send + Sync + 'static> autogen::transaction::Server
 
         let f = self
             .pool
-            .spawn_fn(move || -> Result<Vec<EdgeProperties>, CapnpError> { converters::map_capnp_err(trans.get_all_edge_properties(q)) })
+            .spawn_fn(move || -> Result<Vec<EdgeProperties>, CapnpError> {
+                converters::map_capnp_err(trans.get_all_edge_properties(q))
+            })
             .and_then(move |edge_props| -> Result<(), CapnpError> {
                 let mut res = res.get().init_result(edge_props.len() as u32);
 

--- a/bin/src/common/server.rs
+++ b/bin/src/common/server.rs
@@ -12,6 +12,7 @@ use indradb;
 use indradb::{
     Datastore as IndraDbDatastore, Edge, EdgeProperty, MemoryDatastore, RocksdbDatastore,
     Transaction as IndraDbTransaction, Type, Vertex, VertexProperty,
+    VertexProperties, EdgeProperties,
 };
 use serde_json;
 use std::env;
@@ -333,6 +334,30 @@ impl<T: IndraDbTransaction + Send + Sync + 'static> autogen::transaction::Server
         Promise::from_future(f)
     }
 
+    fn get_all_vertex_properties(
+        &mut self,
+        req: autogen::transaction::GetAllVertexPropertiesParams,
+        mut res: autogen::transaction::GetAllVertexPropertiesResults,
+    ) -> Promise<(), CapnpError> {
+        let trans = self.trans.clone();
+        let cnp_q = pry!(pry!(req.get()).get_q());
+        let q = pry!(converters::to_vertex_query(&cnp_q));
+
+        let f = self
+            .pool
+            .spawn_fn(move || -> Result<Vec<VertexProperties>, CapnpError> { converters::map_capnp_err(trans.get_all_vertex_properties(q)) })
+            .and_then(move |vertex_props| -> Result<(), CapnpError> {
+                let mut res = res.get().init_result(vertex_props.len() as u32);
+
+                for (i, vertex) in vertex_props.into_iter().enumerate() {
+                    converters::from_vertex_properties(&vertex, &mut res.reborrow().get(i as u32));
+                }
+                Ok(())
+            });
+
+        Promise::from_future(f)
+    }
+
     fn set_vertex_properties(
         &mut self,
         req: autogen::transaction::SetVertexPropertiesParams,
@@ -403,6 +428,30 @@ impl<T: IndraDbTransaction + Send + Sync + 'static> autogen::transaction::Server
                     converters::from_edge_property(&property, res.reborrow().get(i as u32));
                 }
 
+                Ok(())
+            });
+
+        Promise::from_future(f)
+    }
+
+    fn get_all_edge_properties(
+        &mut self,
+        req: autogen::transaction::GetAllEdgePropertiesParams,
+        mut res: autogen::transaction::GetAllEdgePropertiesResults,
+    ) -> Promise<(), CapnpError> {
+        let trans = self.trans.clone();
+        let cnp_q = pry!(pry!(req.get()).get_q());
+        let q = pry!(converters::to_edge_query(&cnp_q));
+
+        let f = self
+            .pool
+            .spawn_fn(move || -> Result<Vec<EdgeProperties>, CapnpError> { converters::map_capnp_err(trans.get_all_edge_properties(q)) })
+            .and_then(move |edge_props| -> Result<(), CapnpError> {
+                let mut res = res.get().init_result(edge_props.len() as u32);
+
+                for (i, edge) in edge_props.into_iter().enumerate() {
+                    converters::from_edge_properties(&edge, &mut res.reborrow().get(i as u32));
+                }
                 Ok(())
             });
 

--- a/lib/src/memory/datastore.rs
+++ b/lib/src/memory/datastore.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 
 use crate::errors::Result;
 use crate::models;
+use crate::models::{NamedProperty, VertexProperties, EdgeProperties};
 
 // All of the data is actually stored in this struct, which is stored
 // internally to the datastore itself. This way, we can wrap an rwlock around
@@ -392,6 +393,26 @@ impl Transaction for MemoryTransaction {
         Ok(result)
     }
 
+    fn get_all_vertex_properties<Q: Into<models::VertexQuery>>(&self, q: Q) -> Result<Vec<models::VertexProperties>> {
+
+        let datastore = self.datastore.read().unwrap();
+        let vertex_values = datastore.get_vertex_values_by_query(q.into())?;
+
+        let mut result = Vec::new();
+        for (id, t) in vertex_values {
+            let from = &(id, "".to_string());
+            let to = &(crate::util::next_uuid(id).unwrap(), "".to_string());
+
+            let properties = datastore.vertex_properties.range(from..to);
+            result.push(VertexProperties::new(
+                models::Vertex::with_id(id, t),
+                properties.map(|(n,p)| NamedProperty::new(n.1.clone(),p.clone())).collect())
+            );
+        }
+
+        Ok(result)
+    }
+
     fn set_vertex_properties(&self, q: VertexPropertyQuery, value: &JsonValue) -> Result<()> {
         let mut datastore = self.datastore.write().unwrap();
 
@@ -427,6 +448,27 @@ impl Transaction for MemoryTransaction {
             if let Some(property_value) = property_value {
                 result.push(models::EdgeProperty::new(key, property_value.clone()));
             }
+        }
+
+        Ok(result)
+    }
+
+    fn get_all_edge_properties<Q: Into<models::EdgeQuery>>(&self, q: Q) -> Result<Vec<models::EdgeProperties>> {
+
+        let datastore = self.datastore.read().unwrap();
+        let edge_values = datastore.get_edge_values_by_query(q.into())?;
+
+        let mut result = Vec::new();
+        for (id, t) in edge_values {
+            let from = &(id.clone(), "".to_string());
+
+            let properties = datastore.edge_properties
+                .range(from..)
+                .take_while(|((key,_name),_value)| *key == id);
+            result.push(EdgeProperties::new(
+                models::Edge::new(id.clone(), t),
+                properties.map(|(n,p)| NamedProperty::new(n.1.clone(),p.clone())).collect())
+            );
         }
 
         Ok(result)

--- a/lib/src/models/mod.rs
+++ b/lib/src/models/mod.rs
@@ -7,7 +7,7 @@ mod vertices;
 
 pub use self::bulk_insert::BulkInsertItem;
 pub use self::edges::{Edge, EdgeKey};
-pub use self::properties::{EdgeProperty, VertexProperty};
+pub use self::properties::{EdgeProperty, VertexProperty, VertexProperties, EdgeProperties, NamedProperty};
 pub use self::queries::*;
 pub use self::types::Type;
 pub use self::vertices::Vertex;

--- a/lib/src/models/mod.rs
+++ b/lib/src/models/mod.rs
@@ -7,7 +7,7 @@ mod vertices;
 
 pub use self::bulk_insert::BulkInsertItem;
 pub use self::edges::{Edge, EdgeKey};
-pub use self::properties::{EdgeProperty, VertexProperty, VertexProperties, EdgeProperties, NamedProperty};
+pub use self::properties::{EdgeProperties, EdgeProperty, NamedProperty, VertexProperties, VertexProperty};
 pub use self::queries::*;
 pub use self::types::Type;
 pub use self::vertices::Vertex;

--- a/lib/src/models/properties.rs
+++ b/lib/src/models/properties.rs
@@ -1,6 +1,7 @@
 use super::edges::EdgeKey;
 use serde_json::Value as JsonValue;
 use uuid::Uuid;
+use crate::{Vertex, Edge};
 
 /// Represents a vertex property.
 #[derive(Clone, Debug, PartialEq)]
@@ -21,6 +22,68 @@ impl VertexProperty {
     /// * `value` - The property value.
     pub fn new(id: Uuid, value: JsonValue) -> Self {
         Self { id, value }
+    }
+}
+
+/// Represents a vertex property.
+#[derive(Clone, Debug, PartialEq)]
+pub struct NamedProperty {
+    /// The id of the vertex
+    pub name: String,
+
+    /// The property value.
+    pub value: JsonValue,
+}
+
+impl NamedProperty {
+    /// Creates a new vertex property.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The id of the vertex.
+    /// * `value` - The property value.
+    pub fn new(name: String, value: JsonValue) -> Self {
+        Self { name, value }
+    }
+}
+
+/// A vertex with properties.
+///
+#[derive(Clone, Debug)]
+pub struct VertexProperties {
+    pub vertex: Vertex,
+    pub props: Vec<NamedProperty>,
+}
+
+impl VertexProperties {
+    /// Creates a new vertex+properties for a given Vertex
+    ///
+    /// # Arguments
+    ///
+    /// * `vertex` - The vertex information
+    /// * `props` - The properties
+    pub fn new(vertex: Vertex, props: Vec<NamedProperty>) -> Self {
+        VertexProperties { vertex, props }
+    }
+}
+
+/// A vertex with properties.
+///
+#[derive(Clone, Debug)]
+pub struct EdgeProperties {
+    pub edge: Edge,
+    pub props: Vec<NamedProperty>,
+}
+
+impl EdgeProperties {
+    /// Creates a new edge+properties information for a given Edge
+    ///
+    /// # Arguments
+    ///
+    /// * `edge` - The edge information
+    /// * `props` - The properties
+    pub fn new(edge: Edge, props: Vec<NamedProperty>) -> Self {
+        EdgeProperties { edge, props }
     }
 }
 

--- a/lib/src/models/properties.rs
+++ b/lib/src/models/properties.rs
@@ -1,7 +1,7 @@
 use super::edges::EdgeKey;
+use crate::{Edge, Vertex};
 use serde_json::Value as JsonValue;
 use uuid::Uuid;
-use crate::{Vertex, Edge};
 
 /// Represents a vertex property.
 #[derive(Clone, Debug, PartialEq)]

--- a/lib/src/rdb/datastore.rs
+++ b/lib/src/rdb/datastore.rs
@@ -3,7 +3,7 @@ use super::super::{
 };
 use super::managers::*;
 use crate::errors::Result;
-use crate::models;
+use crate::{models, NamedProperty, VertexProperties, EdgeProperties, EdgeKey};
 use crate::util::next_uuid;
 use chrono::offset::Utc;
 use rocksdb::{DBCompactionStyle, Options, WriteBatch, WriteOptions, DB};
@@ -452,6 +452,25 @@ impl Transaction for RocksdbTransaction {
         Ok(properties)
     }
 
+    fn get_all_vertex_properties<Q: Into<models::VertexQuery>>(&self, q: Q) -> Result<Vec<models::VertexProperties>>{
+        let iterator = self.vertex_query_to_iterator(q.into())?;
+        let manager = VertexPropertyManager::new(self.db.clone());
+
+        let mapped = iterator.map(move |item| {
+            let (id, t) = item?;
+            let vertex = models::Vertex::with_id(id, t);
+
+            let it = manager.iterate_for_owner(id)?;
+            let props : Result<Vec<_>> = it.map(|r| r).collect();
+            let props_iter = props?.into_iter();
+            let props = props_iter.map(|((_,name), value)| NamedProperty::new(name, value)).collect();
+
+            Ok(VertexProperties::new(vertex, props))
+        });
+
+        mapped.collect()
+    }
+
     fn set_vertex_properties(&self, q: VertexPropertyQuery, value: &JsonValue) -> Result<()> {
         let manager = VertexPropertyManager::new(self.db.clone());
         let mut batch = WriteBatch::default();
@@ -493,6 +512,25 @@ impl Transaction for RocksdbTransaction {
         }
 
         Ok(properties)
+    }
+
+    fn get_all_edge_properties<Q: Into<models::EdgeQuery>>(&self, q: Q) -> Result<Vec<models::EdgeProperties>>{
+        let iterator = self.edge_query_to_iterator(q.into())?;
+        let manager = EdgePropertyManager::new(self.db.clone());
+
+        let mapped = iterator.map(move |item| {
+            let (out_id, t, time, in_id) = item?;
+            let edge = models::Edge::new(EdgeKey::new(out_id, t.clone(), in_id), time);
+
+            let it = manager.iterate_for_owner(out_id, &t, in_id)?;
+            let props : Result<Vec<_>> = it.map(|r| r).collect();
+            let props_iter = props?.into_iter();
+            let props = props_iter.map(|((_,_,_,name), value)| NamedProperty::new(name, value)).collect();
+
+            Ok(EdgeProperties::new(edge, props))
+        });
+
+        mapped.collect()
     }
 
     fn set_edge_properties(&self, q: EdgePropertyQuery, value: &JsonValue) -> Result<()> {

--- a/lib/src/tests/macros.rs
+++ b/lib/src/tests/macros.rs
@@ -61,5 +61,6 @@ macro_rules! full_test_impl {
         define_test!(should_handle_edge_properties, $code);
         define_test!(should_not_set_invalid_edge_properties, $code);
         define_test!(should_not_delete_invalid_edge_properties, $code);
+        define_test!(should_get_all_edge_properties, $code);
     };
 }

--- a/lib/src/tests/macros.rs
+++ b/lib/src/tests/macros.rs
@@ -57,6 +57,7 @@ macro_rules! full_test_impl {
         define_test!(should_handle_vertex_properties, $code);
         define_test!(should_not_set_invalid_vertex_properties, $code);
         define_test!(should_not_delete_invalid_vertex_properties, $code);
+        define_test!(should_get_all_vertex_properties, $code);
         define_test!(should_handle_edge_properties, $code);
         define_test!(should_not_set_invalid_edge_properties, $code);
         define_test!(should_not_delete_invalid_edge_properties, $code);

--- a/lib/src/tests/properties.rs
+++ b/lib/src/tests/properties.rs
@@ -37,6 +37,45 @@ pub fn should_handle_vertex_properties<D: Datastore>(datastore: &mut D) {
     assert_eq!(result.len(), 0);
 }
 
+pub fn should_get_all_vertex_properties<D: Datastore>(datastore: &mut D) {
+    let trans = datastore.transaction().unwrap();
+    let t = Type::new("a_vertex").unwrap();
+    let v1 = &Vertex::new(t.clone());
+    let v2 = &Vertex::new(t.clone());
+    let v3 = &Vertex::new(t.clone());
+    trans.create_vertex(v1).unwrap();
+    trans.create_vertex(v2).unwrap();
+    trans.create_vertex(v3).unwrap();
+    let q1 = SpecificVertexQuery::single(v1.id);
+    let q2 = SpecificVertexQuery::single(v2.id);
+    let q3 = SpecificVertexQuery::single(v3.id);
+
+    // Check to make sure there are no initial properties
+    let all_result = trans.get_all_vertex_properties(q2.clone()).unwrap();
+    assert_eq!(all_result.len(), 1);
+    assert_eq!(all_result[0].props.len(), 0);
+
+    // Set and get some properties for v2
+    trans.set_vertex_properties(q2.clone().property("a"), &JsonValue::Bool(false)).unwrap();
+    trans.set_vertex_properties(q2.clone().property("b"), &JsonValue::Bool(true)).unwrap();
+
+    let result_1 = trans.get_all_vertex_properties(q1.clone()).unwrap();
+    assert_eq!(result_1.len(), 1);
+    assert_eq!(result_1[0].props.len(), 0);
+
+    let result_2 = trans.get_all_vertex_properties(q2.clone()).unwrap();
+    assert_eq!(result_2.len(), 1);
+    assert_eq!(result_2[0].props.len(), 2);
+    assert_eq!(result_2[0].props[0].name, "a");
+    assert_eq!(result_2[0].props[0].value, JsonValue::Bool(false));
+    assert_eq!(result_2[0].props[1].name, "b");
+    assert_eq!(result_2[0].props[1].value, JsonValue::Bool(true));
+
+    let result_3 = trans.get_all_vertex_properties(q3.clone()).unwrap();
+    assert_eq!(result_3.len(), 1);
+    assert_eq!(result_3[0].props.len(), 0);
+}
+
 pub fn should_not_set_invalid_vertex_properties<D: Datastore>(datastore: &mut D) {
     let trans = datastore.transaction().unwrap();
     let q = SpecificVertexQuery::single(Uuid::default()).property("foo");
@@ -93,6 +132,47 @@ pub fn should_handle_edge_properties<D: Datastore>(datastore: &mut D) {
     trans.delete_edge_properties(q.clone()).unwrap();
     let result = trans.get_edge_properties(q.clone()).unwrap();
     assert_eq!(result.len(), 0);
+}
+
+pub fn should_get_all_edge_properties<D: Datastore>(datastore: &mut D) {
+    let trans = datastore.transaction().unwrap();
+    let vertex_t = Type::new("test_vertex_type").unwrap();
+    let outbound_v = Vertex::new(vertex_t.clone());
+    let inbound_v = Vertex::new(vertex_t.clone());
+    trans.create_vertex(&outbound_v).unwrap();
+    trans.create_vertex(&inbound_v).unwrap();
+    let edge_t = Type::new("test_edge_type").unwrap();
+    let key = EdgeKey::new(outbound_v.id, edge_t.clone(), inbound_v.id);
+    let eq = SpecificEdgeQuery::single(key.clone());
+    let q1 = eq.clone().property("edge-prop-1");
+    let q2 = eq.clone().property("edge-prop-2");
+
+    trans.create_edge(&key).unwrap();
+
+    // Check to make sure there's no initial value
+    let result = trans.get_all_edge_properties(eq.clone()).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].props.len(), 0);
+
+    // Set and get the value as true
+    trans.set_edge_properties(q1.clone(), &JsonValue::Bool(false)).unwrap();
+    trans.set_edge_properties(q2.clone(), &JsonValue::Bool(true)).unwrap();
+
+    let result = trans.get_all_edge_properties(eq.clone()).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].props.len(), 2);
+    assert_eq!(result[0].props[0].name, "edge-prop-1");
+    assert_eq!(result[0].props[0].value, JsonValue::Bool(false));
+    assert_eq!(result[0].props[1].name, "edge-prop-2");
+    assert_eq!(result[0].props[1].value, JsonValue::Bool(true));
+
+    // Delete & check that they are deleted
+    trans.delete_edge_properties(q1.clone()).unwrap();
+    trans.delete_edge_properties(q2.clone()).unwrap();
+
+    let result = trans.get_all_edge_properties(eq.clone()).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].props.len(), 0);
 }
 
 pub fn should_not_set_invalid_edge_properties<D: Datastore>(datastore: &mut D) {

--- a/lib/src/tests/properties.rs
+++ b/lib/src/tests/properties.rs
@@ -56,8 +56,12 @@ pub fn should_get_all_vertex_properties<D: Datastore>(datastore: &mut D) {
     assert_eq!(all_result[0].props.len(), 0);
 
     // Set and get some properties for v2
-    trans.set_vertex_properties(q2.clone().property("a"), &JsonValue::Bool(false)).unwrap();
-    trans.set_vertex_properties(q2.clone().property("b"), &JsonValue::Bool(true)).unwrap();
+    trans
+        .set_vertex_properties(q2.clone().property("a"), &JsonValue::Bool(false))
+        .unwrap();
+    trans
+        .set_vertex_properties(q2.clone().property("b"), &JsonValue::Bool(true))
+        .unwrap();
 
     let result_1 = trans.get_all_vertex_properties(q1.clone()).unwrap();
     assert_eq!(result_1.len(), 1);

--- a/lib/src/traits.rs
+++ b/lib/src/traits.rs
@@ -133,6 +133,12 @@ pub trait Transaction {
     /// * `name` - The property name.
     fn get_vertex_properties(&self, q: models::VertexPropertyQuery) -> Result<Vec<models::VertexProperty>>;
 
+    /// Gets all vertex properties.
+    ///
+    /// # Arguments
+    /// * `q` - The query to run.
+    fn get_all_vertex_properties<Q: Into<models::VertexQuery>>(&self, q: Q) -> Result<Vec<models::VertexProperties>>;
+
     /// Sets a vertex properties.
     ///
     /// # Arguments
@@ -154,6 +160,12 @@ pub trait Transaction {
     /// * `q` - The query to run.
     /// * `name` - The property name.
     fn get_edge_properties(&self, q: models::EdgePropertyQuery) -> Result<Vec<models::EdgeProperty>>;
+
+    /// Gets all edge properties.
+    ///
+    /// # Arguments
+    /// * `q` - The query to run.
+    fn get_all_edge_properties<Q: Into<models::EdgeQuery>>(&self, q: Q) -> Result<Vec<models::EdgeProperties>>;
 
     /// Sets edge properties.
     ///


### PR DESCRIPTION
With the current API, I don't see a way of fetching all properties for a given vertex or edge. So, there's way of knowing what's stored if you don't have the name of the property.

This PR implements a get_all_vertex_properties and get_all_edge_properties for Transaction, in both the lib and server.