### PR TITLE
Allow usage even without "rocksdb-datastore"-feature

### DIFF
--- a/lib/src/errors.rs
+++ b/lib/src/errors.rs
@@ -20,6 +20,7 @@ impl From<JsonError> for Error {
     }
 }
 
+#[cfg(feature = "rocksdb-datastore")]
 impl From<RocksDbError> for Error {
     fn from(err: RocksDbError) -> Self {
         Error::Rocksdb { inner: err }


### PR DESCRIPTION
If you pull in indradb without the rocksdb feature, the compilation fails. This fixes that.