### PR TITLE
Dynamic iterators

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -7,7 +7,6 @@
 //! layer.
 
 #![cfg_attr(feature = "bench-suite", feature(test))]
-#![feature(generators, generator_trait)]
 
 #[cfg(feature = "bench-suite")]
 extern crate test;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -7,6 +7,7 @@
 //! layer.
 
 #![cfg_attr(feature = "bench-suite", feature(test))]
+#![feature(generators, generator_trait)]
 
 #[cfg(feature = "bench-suite")]
 extern crate test;


### PR DESCRIPTION
Changes the in-memory datastore to use dynamic iterators which should reduce memory pressure. Unfortunately, it wasn't possible to do the same for the rocksdb implementation, as it got too hairy with the managers' heavy reliance on explicit lifetimes.