### PR TITLE
Alternative CI fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,10 @@ matrix:
 env:
   global:
     - RUST_BACKTRACE=1
-    - PATH=$HOME/.local/bin:$HOME/bin:$PATH
+    - PATH=$HOME/.local/bin:$HOME/cached-deps/bin:$PATH
 
 install: ./scripts/install.sh
-script: make test
+script: ulimit -n 1024 && ./scripts/test.py
 before_deploy: ./scripts/before_deploy.sh
 
 deploy:
@@ -69,12 +69,12 @@ before_cache:
   # Travis can't cache files that are not readable by "others"
   - chmod -R a+r $HOME/.cargo
   - chmod -R a+r $TRAVIS_BUILD_DIR/target
-  - chmod -R a+r $HOME/bin
+  - chmod -R a+r $HOME/cached-deps
 cache:
   directories:
   - $HOME/.cargo
   - $TRAVIS_BUILD_DIR/target
-  - $HOME/bin
+  - $HOME/cached-deps
   # Increase default timeout of 3m
   timeout: 500
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,12 +68,10 @@ deploy:
 before_cache:
   # Travis can't cache files that are not readable by "others"
   - chmod -R a+r $HOME/.cargo
-  - chmod -R a+r $TRAVIS_BUILD_DIR/target
   - chmod -R a+r $HOME/cached-deps
 cache:
   directories:
   - $HOME/.cargo
-  - $TRAVIS_BUILD_DIR/target
   - $HOME/cached-deps
   # Increase default timeout of 3m
   timeout: 500

--- a/bin/src/common/client_datastore.rs
+++ b/bin/src/common/client_datastore.rs
@@ -55,7 +55,7 @@ impl ClientDatastore {
     pub fn new(port: u16, mut exec: LocalPool) -> Self {
         let spawner = exec.spawner();
 
-        for _ in 0..5 {
+        for _ in 0..10 {
             if let Ok(client) = exec.run_until(build_client(port, &spawner)) {
                 return Self {
                     client,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,16 +2,32 @@
 
 set -ex
 
-mkdir -p $HOME/bin
+mkdir -p $HOME/cached-deps
 
-if [ ! -f $HOME/bin/capnp ] ; then
+if [ $TRAVIS_OS_NAME = linux ] && [ $TRAVIS_RUST_VERSION = stable ] && [ ! -f $HOME/cached-deps/bin/kcov ] ; then
+    pushd $HOME
+        wget https://github.com/SimonKagstrom/kcov/archive/v36.tar.gz
+        tar xzf v36.tar.gz
+
+        pushd kcov-36
+            mkdir -p build
+            pushd build
+                cmake -DCMAKE_INSTALL_PREFIX=$HOME/cached-deps ..
+                make
+                sudo make install
+            popd
+        popd
+    popd
+fi
+
+if [ ! -f $HOME/cached-deps/bin/capnp ] ; then
     curl -O https://capnproto.org/capnproto-c++-0.6.1.tar.gz
     tar zxf capnproto-c++-0.6.1.tar.gz
     cd capnproto-c++-0.6.1
-    ./configure --prefix=$HOME/bin
+    ./configure --prefix=$HOME/cached-deps
     make -j6 check
     sudo make install
 fi
 
-ls -l $HOME/bin
+ls -l $HOME/cached-deps/bin
 source ~/.cargo/env || true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,14 +5,12 @@ set -ex
 mkdir -p $HOME/bin
 
 if [ ! -f $HOME/bin/capnp ] ; then
-    mkdir -p $HOME/capnp
     curl -O https://capnproto.org/capnproto-c++-0.6.1.tar.gz
     tar zxf capnproto-c++-0.6.1.tar.gz
     cd capnproto-c++-0.6.1
-    ./configure --prefix=$HOME/capnp
+    ./configure --prefix=$HOME/bin
     make -j6 check
     sudo make install
-    cp $HOME/capnp/bin/* $HOME/bin/
 fi
 
 ls -l $HOME/bin

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import shutil
+import subprocess
+
+LIB_TESTS = ["indradb"]
+BIN_TESTS = ["common"]
+TEST_FILE_PATTERN_TEMPLATE = r"^%s-[0-9a-f]{16}$"
+
+EXCLUDE_PATTERNS = [
+    "/.cargo",
+    "target",
+    "/usr",
+    "lib/src/tests",
+    "lib/src/benches",
+    "bin/src/common/autogen",
+    "tests.rs"
+]
+
+def get_test_file_name(test_name):
+    test_file_pattern = TEST_FILE_PATTERN_TEMPLATE % test_name
+
+    for file in os.listdir("target/debug"):
+        if re.match(test_file_pattern, file):
+            return file
+
+    raise Exception("No file matching the pattern `%s` in `target/debug`" % test_file_pattern)
+
+def run(args, cwd=".", env=None):
+    print("%s => %s" % (cwd, args))
+    subprocess.check_call(args, cwd=cwd, env=env)
+
+def main():
+    test_bin_env = os.environ.copy()
+    test_bin_env["ROCKSDB_MAX_OPEN_FILES"] = "1"
+
+    if os.environ["TRAVIS_OS_NAME"] == "linux" and os.environ["TRAVIS_RUST_VERSION"] == "stable":
+        shutil.rmtree("target/kcov", ignore_errors=True)
+
+        run(["cargo", "test", "--features=test-suite,rocksdb-datastore", "--no-run"], cwd="lib")
+        run(["cargo", "test", "--features=test-suite", "--no-run"], cwd="bin", env=test_bin_env)
+
+        for lib_test in LIB_TESTS:
+            run([
+                "kcov", "--verify",
+                "--exclude-pattern=%s" % ",".join(EXCLUDE_PATTERNS),
+                "../target/kcov",
+                "../target/debug/%s" % get_test_file_name(lib_test),
+            ], cwd="lib")
+
+        for bin_test in BIN_TESTS:
+            run([
+                "kcov", "--verify",
+                "--exclude-pattern=%s" % ",".join(EXCLUDE_PATTERNS),
+                "../target/kcov",
+                "../target/debug/%s" % get_test_file_name(bin_test),
+            ], cwd="bin")
+
+        run([
+            "kcov", "--merge", "--verify",
+            "--exclude-pattern=%s" % ",".join(EXCLUDE_PATTERNS),
+            "--coveralls-id=%s" % os.environ["TRAVIS_JOB_ID"],
+            "target/kcov", "target/kcov",
+        ])
+    else:
+        run(["cargo", "test", "--features=test-suite,rocksdb-datastore"], cwd="lib")
+        run(["cargo", "test", "--features=test-suite"], cwd="bin", env=test_bin_env)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Instead of removing coverage analysis, this would remove caching of the build target directory. This means rust would have to rebuild from scratch on every CI run, but that may not be as bad as it seems; nightly has to rebuild on virtually every run anyway, and CI will only be as fast as the slowest job.