### PR TITLE
Sled transactions

### DIFF
--- a/bin/src/server/main.rs
+++ b/bin/src/server/main.rs
@@ -61,9 +61,7 @@ fn main() -> Result<(), errors::Error> {
             }
         };
 
-        let datastore = sled_config
-            .open(path)
-            .expect("Expected to be able to create the Sled datastore");
+        let datastore = indradb::SledDatastore::new_with_config(path, sled_config).expect("Expected to be able to create the Sled datastore");
 
         exec.run_until(common::server::run(listener, datastore, exec.spawner()))?;
         Ok(())

--- a/bin/src/server/main.rs
+++ b/bin/src/server/main.rs
@@ -61,7 +61,8 @@ fn main() -> Result<(), errors::Error> {
             }
         };
 
-        let datastore = indradb::SledDatastore::new_with_config(path, sled_config).expect("Expected to be able to create the Sled datastore");
+        let datastore = indradb::SledDatastore::new_with_config(path, sled_config)
+            .expect("Expected to be able to create the Sled datastore");
 
         exec.run_until(common::server::run(listener, datastore, exec.spawner()))?;
         Ok(())

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -38,4 +38,4 @@ rocksdb = { version = "0.15.0", optional = true }
 byteorder = { version = "^1.3.4", optional = true }
 
 # Sled dependencies
-sled = { version = "0.33.0", optional = true, features = ["compression", "no_metrics"] }
+sled = { version = "0.34.6", optional = true, features = ["compression", "no_metrics"] }

--- a/lib/src/errors.rs
+++ b/lib/src/errors.rs
@@ -2,26 +2,26 @@
 use rocksdb::Error as RocksDbError;
 use serde_json::Error as JsonError;
 #[cfg(feature = "sled-datastore")]
-use sled::{Error as SledError, transaction::TransactionError as SledTransactionError};
+use sled::{transaction::TransactionError as SledTransactionError, Error as SledError};
 use std::result::Result as StdResult;
 
 #[derive(Debug, Fail)]
 pub enum Error {
     #[fail(display = "json error: {}", inner)]
     Json { inner: JsonError },
-    
+
     #[cfg(feature = "rocksdb-datastore")]
     #[fail(display = "rocksdb error: {}", inner)]
     Rocksdb { inner: RocksDbError },
-    
+
     #[cfg(feature = "sled-datastore")]
     #[fail(display = "sled error: {}", inner)]
     Sled { inner: SledError },
-    
+
     #[cfg(feature = "sled-datastore")]
     #[fail(display = "sled transaction aborted")]
     SledTransactionAborted,
-    
+
     #[fail(display = "UUID already taken")]
     UuidTaken,
 }
@@ -51,7 +51,7 @@ impl From<SledTransactionError<()>> for Error {
     fn from(err: SledTransactionError<()>) -> Self {
         match err {
             SledTransactionError::Abort(_) => Error::SledTransactionAborted,
-            SledTransactionError::Storage(err) => Error::Sled { inner: err }
+            SledTransactionError::Storage(err) => Error::Sled { inner: err },
         }
     }
 }

--- a/lib/src/rdb/datastore.rs
+++ b/lib/src/rdb/datastore.rs
@@ -486,7 +486,7 @@ impl Transaction for RocksdbTransaction {
             let vertex = Vertex::with_id(id, t);
 
             let it = manager.iterate_for_owner(id)?;
-            let props: Result<Vec<_>> = it.map(|r| r).collect();
+            let props: Result<Vec<_>> = it.collect();
             let props_iter = props?.into_iter();
             let props = props_iter
                 .map(|((_, name), value)| NamedProperty::new(name, value))
@@ -549,7 +549,7 @@ impl Transaction for RocksdbTransaction {
         let iter = iter.map(move |(out_id, t, time, in_id)| {
             let edge = Edge::new(EdgeKey::new(out_id, t.clone(), in_id), time);
             let it = manager.iterate_for_owner(out_id, &t, in_id)?;
-            let props: Result<Vec<_>> = it.map(|r| r).collect();
+            let props: Result<Vec<_>> = it.collect();
             let props_iter = props?.into_iter();
             let props = props_iter
                 .map(|((_, _, _, name), value)| NamedProperty::new(name, value))

--- a/lib/src/sledds/datastore.rs
+++ b/lib/src/sledds/datastore.rs
@@ -393,7 +393,7 @@ impl Transaction for SledTransaction {
             let vertex = models::Vertex::with_id(id, t);
 
             let it = manager.iterate_for_owner(id);
-            let props: Result<Vec<_>> = it.map(|r| r).collect();
+            let props: Result<Vec<_>> = it.collect();
             let props_iter = props?.into_iter();
             let props = props_iter
                 .map(|((_, name), value)| models::NamedProperty::new(name, value))
@@ -453,7 +453,7 @@ impl Transaction for SledTransaction {
             let (out_id, t, time, in_id) = item?;
             let edge = Edge::new(EdgeKey::new(out_id, t.clone(), in_id), time);
             let it = manager.iterate_for_owner(out_id, &t, in_id);
-            let props: Result<Vec<_>> = it.map(|r| r).collect();
+            let props: Result<Vec<_>> = it.collect();
             let props_iter = props?.into_iter();
             let props = props_iter
                 .map(|((_, _, _, name), value)| NamedProperty::new(name, value))

--- a/lib/src/sledds/datastore.rs
+++ b/lib/src/sledds/datastore.rs
@@ -111,8 +111,8 @@ impl Datastore for SledDatastore {
     {
         let vertex_manager = VertexManager::new(&self.holder);
         let edge_manager = EdgeManager::new(&self.holder);
-        let vertex_property_manager = VertexPropertyManager::new(&self.holder.vertex_properties);
-        let edge_property_manager = EdgePropertyManager::new(&self.holder.edge_properties);
+        let vertex_property_manager = VertexPropertyManager::new(&self.holder);
+        let edge_property_manager = EdgePropertyManager::new(&self.holder);
 
         for item in items {
             match item {
@@ -404,7 +404,7 @@ impl Transaction for SledTransaction {
     }
 
     fn get_vertex_properties(&self, q: VertexPropertyQuery) -> Result<Vec<models::VertexProperty>> {
-        let manager = VertexPropertyManager::new(&self.holder.vertex_properties);
+        let manager = VertexPropertyManager::new(&self.holder);
         let mut properties = Vec::new();
 
         for item in self.vertex_query_to_iterator(q.inner)? {
@@ -420,7 +420,7 @@ impl Transaction for SledTransaction {
     }
 
     fn get_all_vertex_properties<Q: Into<VertexQuery>>(&self, q: Q) -> Result<Vec<models::VertexProperties>> {
-        let manager = VertexPropertyManager::new(&self.holder.vertex_properties);
+        let manager = VertexPropertyManager::new(&self.holder);
         let iterator = self.vertex_query_to_iterator(q.into())?;
 
         let iter = iterator.map(move |item| {
@@ -441,7 +441,7 @@ impl Transaction for SledTransaction {
     }
 
     fn set_vertex_properties(&self, q: VertexPropertyQuery, value: &JsonValue) -> Result<()> {
-        let manager = VertexPropertyManager::new(&self.holder.vertex_properties);
+        let manager = VertexPropertyManager::new(&self.holder);
 
         for item in self.vertex_query_to_iterator(q.inner)? {
             let (id, _) = item?;
@@ -451,7 +451,7 @@ impl Transaction for SledTransaction {
     }
 
     fn delete_vertex_properties(&self, q: VertexPropertyQuery) -> Result<()> {
-        let manager = VertexPropertyManager::new(&self.holder.vertex_properties);
+        let manager = VertexPropertyManager::new(&self.holder);
 
         for item in self.vertex_query_to_iterator(q.inner)? {
             let (id, _) = item?;
@@ -461,7 +461,7 @@ impl Transaction for SledTransaction {
     }
 
     fn get_edge_properties(&self, q: EdgePropertyQuery) -> Result<Vec<models::EdgeProperty>> {
-        let manager = EdgePropertyManager::new(&self.holder.edge_properties);
+        let manager = EdgePropertyManager::new(&self.holder);
         let mut properties = Vec::new();
 
         for item in self.edge_query_to_iterator(q.inner)? {
@@ -478,7 +478,7 @@ impl Transaction for SledTransaction {
     }
 
     fn get_all_edge_properties<Q: Into<EdgeQuery>>(&self, q: Q) -> Result<Vec<EdgeProperties>> {
-        let manager = EdgePropertyManager::new(&self.holder.edge_properties);
+        let manager = EdgePropertyManager::new(&self.holder);
         let iterator = self.edge_query_to_iterator(q.into())?;
 
         let iter = iterator.map(move |item| {
@@ -498,7 +498,7 @@ impl Transaction for SledTransaction {
     }
 
     fn set_edge_properties(&self, q: EdgePropertyQuery, value: &JsonValue) -> Result<()> {
-        let manager = EdgePropertyManager::new(&self.holder.edge_properties);
+        let manager = EdgePropertyManager::new(&self.holder);
 
         for item in self.edge_query_to_iterator(q.inner)? {
             let (outbound_id, t, _, inbound_id) = item?;
@@ -508,7 +508,7 @@ impl Transaction for SledTransaction {
     }
 
     fn delete_edge_properties(&self, q: EdgePropertyQuery) -> Result<()> {
-        let manager = EdgePropertyManager::new(&self.holder.edge_properties);
+        let manager = EdgePropertyManager::new(&self.holder);
 
         for item in self.edge_query_to_iterator(q.inner)? {
             let (outbound_id, t, _, inbound_id) = item?;

--- a/lib/src/sledds/datastore.rs
+++ b/lib/src/sledds/datastore.rs
@@ -13,7 +13,7 @@ use crate::util::{next_uuid, remove_nones_from_iterator};
 
 use chrono::offset::Utc;
 use serde_json::Value as JsonValue;
-use sled::{Db, Batch, Config};
+use sled::{Batch, Config, Db};
 use uuid::Uuid;
 
 /// A datastore that is backed by Sled.
@@ -483,7 +483,7 @@ impl Transaction for SledTransaction {
             let (outbound_id, t, _, inbound_id) = item?;
             manager.delete(&mut batch, outbound_id, &t, inbound_id, &q.name);
         }
-        
+
         self.db.apply_batch(batch)?;
         Ok(())
     }

--- a/lib/src/sledds/managers.rs
+++ b/lib/src/sledds/managers.rs
@@ -1,12 +1,11 @@
 use super::super::bytes::*;
 use crate::errors::Result;
 use crate::models;
-use crate::sledds::datastore::SledHolder;
 use chrono::offset::Utc;
 use chrono::DateTime;
 use serde_json::Value as JsonValue;
 use sled::Result as SledResult;
-use sled::{IVec, Iter as DbIterator, Tree};
+use sled::{IVec, Iter as DbIterator, Tree, Batch, Transactional, Config, Db};
 use std::io::Cursor;
 use std::ops::Deref;
 use std::u8;
@@ -26,7 +25,160 @@ fn take_while_prefixed(iterator: DbIterator, prefix: Vec<u8>) -> impl Iterator<I
     })
 }
 
-pub struct VertexManager<'db: 'tree, 'tree> {
+#[derive(Copy, Clone, Default, Debug)]
+pub struct SledConfig {
+    pub(crate) use_compression: bool,
+    pub(crate) compression_factor: Option<i32>,
+}
+
+impl SledConfig {
+    /// Creates a new sled config with zstd compression enabled.
+    ///
+    /// # Arguments
+    /// * `factor` - The zstd compression factor to use. If unspecified, this
+    ///   will default to 5.
+    pub fn with_compression(factor: Option<i32>) -> SledConfig {
+        return SledConfig {
+            use_compression: true,
+            compression_factor: factor,
+        };
+    }
+}
+
+/// The meat of a Sled datastore
+pub struct SledHolder {
+    pub(crate) db: Db,
+    pub(crate) vertices: Tree,
+    pub(crate) edges: Tree,
+    pub(crate) edge_ranges: Tree,
+    pub(crate) reversed_edge_ranges: Tree,
+    pub(crate) vertex_properties: Tree,
+    pub(crate) edge_properties: Tree,
+}
+
+impl<'ds> SledHolder {
+    /// The meat of a Sled datastore.
+    ///
+    /// # Arguments
+    /// * `path` - The file path to the Sled database.
+    /// * `config` - Sled options to pass in.
+    pub fn new(path: &str, config: SledConfig) -> Result<SledHolder> {
+        let mut sled_config = Config::default().path(path);
+
+        if config.use_compression {
+            sled_config = sled_config.use_compression(true);
+        }
+
+        if let Some(compression_factor) = config.compression_factor {
+            sled_config = sled_config.compression_factor(compression_factor);
+        }
+
+        let db = sled_config.open()?;
+
+        Ok(SledHolder {
+            vertices: db.open_tree("vertices")?,
+            edges: db.open_tree("edges")?,
+            edge_ranges: db.open_tree("edge_ranges")?,
+            reversed_edge_ranges: db.open_tree("reversed_edge_ranges")?,
+            vertex_properties: db.open_tree("vertex_properties")?,
+            edge_properties: db.open_tree("edge_properties")?,
+            db,
+        })
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct UberBatch {
+    pub vertices: Option<Batch>,
+    pub edges: Option<Batch>,
+    pub edge_ranges: Option<Batch>,
+    pub reversed_edge_ranges: Option<Batch>,
+    pub vertex_properties: Option<Batch>,
+    pub edge_properties: Option<Batch>,
+}
+
+impl UberBatch {
+    pub(crate) fn vertices(&mut self) -> &mut Batch {
+        if self.vertices.is_none() {
+            self.vertices = Some(Batch::default());
+        }
+        self.vertices.as_mut().unwrap()
+    }
+
+    pub(crate) fn edges(&mut self) -> &mut Batch {
+        if self.edges.is_none() {
+            self.edges = Some(Batch::default());
+        }
+        self.edges.as_mut().unwrap()
+    }
+
+    pub(crate) fn edge_ranges(&mut self) -> &mut Batch {
+        if self.edge_ranges.is_none() {
+            self.edge_ranges = Some(Batch::default());
+        }
+        self.edge_ranges.as_mut().unwrap()
+    }
+
+    pub(crate) fn reversed_edge_ranges(&mut self) -> &mut Batch {
+        if self.reversed_edge_ranges.is_none() {
+            self.reversed_edge_ranges = Some(Batch::default());
+        }
+        self.reversed_edge_ranges.as_mut().unwrap()
+    }
+
+    pub(crate) fn vertex_properties(&mut self) -> &mut Batch {
+        if self.vertex_properties.is_none() {
+            self.vertex_properties = Some(Batch::default());
+        }
+        self.vertex_properties.as_mut().unwrap()
+    }
+
+    pub(crate) fn edge_properties(&mut self) -> &mut Batch {
+        if self.edge_properties.is_none() {
+            self.edge_properties = Some(Batch::default());
+        }
+        self.edge_properties.as_mut().unwrap()
+    }
+
+    pub(crate) fn apply(self, holder: &SledHolder) -> Result<()> {
+        // TODO: find a better way to do this that minimizes the number of
+        // transactions
+        let trees = (
+            &holder.vertices,
+            &holder.edges,
+            &holder.edge_ranges,
+            &holder.reversed_edge_ranges,
+            &holder.vertex_properties,
+            &holder.edge_properties,
+        );
+
+        trees.transaction(|(vertices_tree, edges_tree, edge_ranges_tree, reversed_edge_ranges_tree, vertex_properties_tree, edge_properties_tree)| {
+            if let Some(vertices_batch) = &self.vertices {
+                vertices_tree.apply_batch(&vertices_batch)?;
+            }
+            if let Some(edges_batch) = &self.edges {
+                edges_tree.apply_batch(&edges_batch)?;
+            }
+            if let Some(edge_ranges_batch) = &self.edge_ranges {
+                edge_ranges_tree.apply_batch(&edge_ranges_batch)?;
+            }
+            if let Some(reversed_edge_ranges_batch) = &self.reversed_edge_ranges {
+                reversed_edge_ranges_tree.apply_batch(&reversed_edge_ranges_batch)?;
+            }
+            if let Some(vertex_properties_batch) = &self.vertex_properties {
+                vertex_properties_tree.apply_batch(&vertex_properties_batch)?;
+            }
+            if let Some(edge_properties_batch) = &self.edge_properties {
+                edge_properties_tree.apply_batch(&edge_properties_batch)?;
+            }
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+}
+
+pub(crate) struct VertexManager<'db: 'tree, 'tree> {
     pub holder: &'db SledHolder,
     pub tree: &'tree Tree,
 }
@@ -35,12 +187,12 @@ impl<'db: 'tree, 'tree> VertexManager<'db, 'tree> {
     pub fn new(ds: &'db SledHolder) -> Self {
         VertexManager {
             holder: ds,
-            tree: &ds.db.deref(),
+            tree: &ds.vertices,
         }
     }
 
-    fn key(&self, id: Uuid) -> Vec<u8> {
-        build(&[Component::Uuid(id)])
+    fn key(&self, id: Uuid) -> IVec {
+        build(&[Component::Uuid(id)]).into()
     }
 
     pub fn exists(&self, id: Uuid) -> Result<bool> {
@@ -73,11 +225,11 @@ impl<'db: 'tree, 'tree> VertexManager<'db, 'tree> {
         })
     }
 
-    pub fn iterate_for_range<'a>(&'a self, id: Uuid) -> Result<impl Iterator<Item = Result<VertexItem>> + 'a> {
+    pub fn iterate_for_range<'a>(&'a self, id: Uuid) -> impl Iterator<Item = Result<VertexItem>> + 'a {
         let low_key = build(&[Component::Uuid(id)]);
         let low_key_bytes: &[u8] = low_key.as_ref();
         let iter = self.tree.range(low_key_bytes..);
-        Ok(self.iterate(iter))
+        self.iterate(iter)
     }
 
     pub fn create(&self, vertex: &models::Vertex) -> Result<()> {
@@ -86,23 +238,24 @@ impl<'db: 'tree, 'tree> VertexManager<'db, 'tree> {
         Ok(())
     }
 
-    pub fn delete(&self, id: Uuid) -> Result<()> {
-        self.tree.remove(&self.key(id))?;
+    pub fn delete(&self, batch: &mut UberBatch, id: Uuid) -> Result<()> {
+        batch.vertices().remove(&self.key(id));
 
         let vertex_property_manager = VertexPropertyManager::new(&self.holder);
-        for item in vertex_property_manager.iterate_for_owner(id)? {
+        for item in vertex_property_manager.iterate_for_owner(id) {
             let ((vertex_property_owner_id, vertex_property_name), _) = item?;
-            vertex_property_manager.delete(vertex_property_owner_id, &vertex_property_name[..])?;
+            vertex_property_manager.delete(batch, vertex_property_owner_id, &vertex_property_name[..]);
         }
 
         let edge_manager = EdgeManager::new(&self.holder);
 
         {
             let edge_range_manager = EdgeRangeManager::new(&self.holder);
-            for item in edge_range_manager.iterate_for_owner(id)? {
+            for item in edge_range_manager.iterate_for_owner(id) {
                 let (edge_range_outbound_id, edge_range_t, edge_range_update_datetime, edge_range_inbound_id) = item?;
                 debug_assert_eq!(edge_range_outbound_id, id);
                 edge_manager.delete(
+                    batch,
                     edge_range_outbound_id,
                     &edge_range_t,
                     edge_range_inbound_id,
@@ -113,7 +266,7 @@ impl<'db: 'tree, 'tree> VertexManager<'db, 'tree> {
 
         {
             let reversed_edge_range_manager = EdgeRangeManager::new_reversed(&self.holder);
-            for item in reversed_edge_range_manager.iterate_for_owner(id)? {
+            for item in reversed_edge_range_manager.iterate_for_owner(id) {
                 let (
                     reversed_edge_range_inbound_id,
                     reversed_edge_range_t,
@@ -122,6 +275,7 @@ impl<'db: 'tree, 'tree> VertexManager<'db, 'tree> {
                 ) = item?;
                 debug_assert_eq!(reversed_edge_range_inbound_id, id);
                 edge_manager.delete(
+                    batch,
                     reversed_edge_range_outbound_id,
                     &reversed_edge_range_t,
                     reversed_edge_range_inbound_id,
@@ -133,7 +287,7 @@ impl<'db: 'tree, 'tree> VertexManager<'db, 'tree> {
     }
 }
 
-pub struct EdgeManager<'db: 'tree, 'tree> {
+pub(crate) struct EdgeManager<'db: 'tree, 'tree> {
     pub holder: &'db SledHolder,
     pub tree: &'tree Tree,
 }
@@ -146,12 +300,12 @@ impl<'db, 'tree> EdgeManager<'db, 'tree> {
         }
     }
 
-    fn key(&self, outbound_id: Uuid, t: &models::Type, inbound_id: Uuid) -> Vec<u8> {
+    fn key(&self, outbound_id: Uuid, t: &models::Type, inbound_id: Uuid) -> IVec {
         build(&[
             Component::Uuid(outbound_id),
             Component::Type(t),
             Component::Uuid(inbound_id),
-        ])
+        ]).into()
     }
 
     pub fn get(&self, outbound_id: Uuid, t: &models::Type, inbound_id: Uuid) -> Result<Option<DateTime<Utc>>> {
@@ -166,6 +320,7 @@ impl<'db, 'tree> EdgeManager<'db, 'tree> {
 
     pub fn set(
         &self,
+        batch: &mut UberBatch,
         outbound_id: Uuid,
         t: &models::Type,
         inbound_id: Uuid,
@@ -175,78 +330,81 @@ impl<'db, 'tree> EdgeManager<'db, 'tree> {
         let reversed_edge_range_manager = EdgeRangeManager::new_reversed(&self.holder);
 
         if let Some(update_datetime) = self.get(outbound_id, t, inbound_id)? {
-            edge_range_manager.delete(outbound_id, t, update_datetime, inbound_id)?;
-            reversed_edge_range_manager.delete(inbound_id, t, update_datetime, outbound_id)?;
+            edge_range_manager.delete(batch, outbound_id, t, update_datetime, inbound_id);
+            reversed_edge_range_manager.delete(batch, inbound_id, t, update_datetime, outbound_id);
         }
 
         let key = self.key(outbound_id, t, inbound_id);
-        self.tree
-            .insert(key, build(&[Component::DateTime(new_update_datetime)]))?;
-        edge_range_manager.set(outbound_id, t, new_update_datetime, inbound_id)?;
-        reversed_edge_range_manager.set(inbound_id, t, new_update_datetime, outbound_id)?;
+        batch.edges().insert(key, build(&[Component::DateTime(new_update_datetime)]));
+        edge_range_manager.set(batch, outbound_id, t, new_update_datetime, inbound_id);
+        reversed_edge_range_manager.set(batch, inbound_id, t, new_update_datetime, outbound_id);
         Ok(())
     }
 
     pub fn delete(
         &self,
+        batch: &mut UberBatch,
         outbound_id: Uuid,
         t: &models::Type,
         inbound_id: Uuid,
         update_datetime: DateTime<Utc>,
     ) -> Result<()> {
-        self.tree.remove(&self.key(outbound_id, t, inbound_id))?;
+        batch.edges().remove(&self.key(outbound_id, t, inbound_id));
 
         let edge_range_manager = EdgeRangeManager::new(&self.holder);
-        edge_range_manager.delete(outbound_id, t, update_datetime, inbound_id)?;
+        edge_range_manager.delete(batch, outbound_id, t, update_datetime, inbound_id);
 
         let reversed_edge_range_manager = EdgeRangeManager::new_reversed(&self.holder);
-        reversed_edge_range_manager.delete(inbound_id, t, update_datetime, outbound_id)?;
+        reversed_edge_range_manager.delete(batch, inbound_id, t, update_datetime, outbound_id);
 
         let edge_property_manager = EdgePropertyManager::new(&self.holder);
-        for item in edge_property_manager.iterate_for_owner(outbound_id, t, inbound_id)? {
+        for item in edge_property_manager.iterate_for_owner(outbound_id, t, inbound_id) {
             let ((edge_property_outbound_id, edge_property_t, edge_property_inbound_id, edge_property_name), _) = item?;
             edge_property_manager.delete(
+                batch,
                 edge_property_outbound_id,
                 &edge_property_t,
                 edge_property_inbound_id,
                 &edge_property_name[..],
-            )?;
+            );
         }
         Ok(())
     }
 }
 
-pub struct EdgeRangeManager<'tree> {
+pub(crate) struct EdgeRangeManager<'tree> {
     pub tree: &'tree Tree,
+    reversed: bool
 }
 
 impl<'tree> EdgeRangeManager<'tree> {
     pub fn new<'db: 'tree>(ds: &'db SledHolder) -> Self {
-        EdgeRangeManager { tree: &ds.edge_ranges }
+        EdgeRangeManager { tree: &ds.edge_ranges, reversed: false }
     }
 
     pub fn new_reversed<'db: 'tree>(ds: &'db SledHolder) -> Self {
         EdgeRangeManager {
             tree: &ds.reversed_edge_ranges,
+            reversed: true,
         }
     }
 
-    fn key(&self, first_id: Uuid, t: &models::Type, update_datetime: DateTime<Utc>, second_id: Uuid) -> Vec<u8> {
+    fn key(&self, first_id: Uuid, t: &models::Type, update_datetime: DateTime<Utc>, second_id: Uuid) -> IVec {
         build(&[
             Component::Uuid(first_id),
             Component::Type(t),
             Component::DateTime(update_datetime),
             Component::Uuid(second_id),
-        ])
+        ]).into()
     }
 
     fn iterate<'it>(
         &self,
         iterator: DbIterator,
         prefix: Vec<u8>,
-    ) -> Result<impl Iterator<Item = Result<EdgeRangeItem>> + 'it> {
+    ) -> impl Iterator<Item = Result<EdgeRangeItem>> + 'it {
         let filtered = take_while_prefixed(iterator, prefix);
-        Ok(filtered.map(move |item| -> Result<EdgeRangeItem> {
+        filtered.map(move |item| -> Result<EdgeRangeItem> {
             let (k, _) = item?;
             let mut cursor = Cursor::new(k);
             let first_id = read_uuid(&mut cursor);
@@ -254,7 +412,7 @@ impl<'tree> EdgeRangeManager<'tree> {
             let update_datetime = read_datetime(&mut cursor);
             let second_id = read_uuid(&mut cursor);
             Ok((first_id, t, update_datetime, second_id))
-        }))
+        })
     }
 
     pub fn iterate_for_range<'iter, 'trans: 'iter>(
@@ -262,7 +420,7 @@ impl<'tree> EdgeRangeManager<'tree> {
         id: Uuid,
         t: Option<&models::Type>,
         high: Option<DateTime<Utc>>,
-    ) -> Result<Box<dyn Iterator<Item = Result<EdgeRangeItem>> + 'iter>> {
+    ) -> Box<dyn Iterator<Item = Result<EdgeRangeItem>> + 'iter> {
         match t {
             Some(t) => {
                 let high = high.unwrap_or_else(|| *MAX_DATETIME);
@@ -270,13 +428,13 @@ impl<'tree> EdgeRangeManager<'tree> {
                 let low_key = build(&[Component::Uuid(id), Component::Type(t), Component::DateTime(high)]);
                 let low_key_bytes: &[u8] = low_key.as_ref();
                 let iterator = self.tree.range(low_key_bytes..);
-                Ok(Box::new(self.iterate(iterator, prefix)?))
+                Box::new(self.iterate(iterator, prefix))
             }
             None => {
                 let prefix = build(&[Component::Uuid(id)]);
                 let prefix_bytes: &[u8] = prefix.as_ref();
                 let iterator = self.tree.range(prefix_bytes..);
-                let mapped = self.iterate(iterator, prefix)?;
+                let mapped = self.iterate(iterator, prefix);
 
                 if let Some(high) = high {
                     // We can filter out `update_datetime`s greater than
@@ -290,9 +448,9 @@ impl<'tree> EdgeRangeManager<'tree> {
                         }
                     });
 
-                    Ok(Box::new(filtered))
+                    Box::new(filtered)
                 } else {
-                    Ok(Box::new(mapped))
+                    Box::new(mapped)
                 }
             }
         }
@@ -301,31 +459,38 @@ impl<'tree> EdgeRangeManager<'tree> {
     pub fn iterate_for_owner<'iter, 'trans: 'iter>(
         &'trans self,
         id: Uuid,
-    ) -> Result<impl Iterator<Item = Result<EdgeRangeItem>> + 'iter> {
+    ) -> impl Iterator<Item = Result<EdgeRangeItem>> + 'iter {
         let prefix: Vec<u8> = build(&[Component::Uuid(id)]);
         let iterator = self.tree.scan_prefix(&prefix);
         self.iterate(iterator, prefix)
     }
 
-    pub fn set(&self, first_id: Uuid, t: &models::Type, update_datetime: DateTime<Utc>, second_id: Uuid) -> Result<()> {
+    pub fn set(&self, batch: &mut UberBatch, first_id: Uuid, t: &models::Type, update_datetime: DateTime<Utc>, second_id: Uuid) {
         let key = self.key(first_id, t, update_datetime, second_id);
-        self.tree.insert(&key, &[])?;
-        Ok(())
+        if self.reversed {
+            batch.reversed_edge_ranges().insert(&key, &[]);
+        } else {
+            batch.edge_ranges().insert(&key, &[]);
+        }
     }
 
     pub fn delete(
         &self,
+        batch: &mut UberBatch,
         first_id: Uuid,
         t: &models::Type,
         update_datetime: DateTime<Utc>,
         second_id: Uuid,
-    ) -> Result<()> {
-        self.tree.remove(&self.key(first_id, t, update_datetime, second_id))?;
-        Ok(())
+    ) {
+        if self.reversed {
+            batch.reversed_edge_ranges().remove(&self.key(first_id, t, update_datetime, second_id));
+        } else {
+            batch.edge_ranges().remove(&self.key(first_id, t, update_datetime, second_id));
+        }
     }
 }
 
-pub struct VertexPropertyManager<'tree> {
+pub(crate) struct VertexPropertyManager<'tree> {
     pub tree: &'tree Tree,
 }
 
@@ -335,15 +500,15 @@ impl<'tree> VertexPropertyManager<'tree> {
     }
 
 
-    fn key(&self, vertex_id: Uuid, name: &str) -> Vec<u8> {
-        build(&[Component::Uuid(vertex_id), Component::UnsizedString(name)])
+    fn key(&self, vertex_id: Uuid, name: &str) -> IVec {
+        build(&[Component::Uuid(vertex_id), Component::UnsizedString(name)]).into()
     }
 
-    pub fn iterate_for_owner(&self, vertex_id: Uuid) -> Result<impl Iterator<Item = Result<OwnedPropertyItem>> + '_> {
+    pub fn iterate_for_owner(&self, vertex_id: Uuid) -> impl Iterator<Item = Result<OwnedPropertyItem>> + '_ {
         let prefix = build(&[Component::Uuid(vertex_id)]);
         let iterator = self.tree.scan_prefix(&prefix);
 
-        Ok(iterator.map(move |item| -> Result<OwnedPropertyItem> {
+        iterator.map(move |item| -> Result<OwnedPropertyItem> {
             let (k, v) = item?;
             let mut cursor = Cursor::new(k);
             let owner_id = read_uuid(&mut cursor);
@@ -351,7 +516,7 @@ impl<'tree> VertexPropertyManager<'tree> {
             let name = read_unsized_string(&mut cursor);
             let value = serde_json::from_slice(&v)?;
             Ok(((owner_id, name), value))
-        }))
+        })
     }
 
     pub fn get(&self, vertex_id: Uuid, name: &str) -> Result<Option<JsonValue>> {
@@ -366,17 +531,16 @@ impl<'tree> VertexPropertyManager<'tree> {
     pub fn set(&self, vertex_id: Uuid, name: &str, value: &JsonValue) -> Result<()> {
         let key = self.key(vertex_id, name);
         let value_json = serde_json::to_vec(value)?;
-        self.tree.insert(key.as_slice(), value_json.as_slice())?;
+        self.tree.insert(key, value_json.as_slice())?;
         Ok(())
     }
 
-    pub fn delete(&self, vertex_id: Uuid, name: &str) -> Result<()> {
-        self.tree.remove(&self.key(vertex_id, name))?;
-        Ok(())
+    pub fn delete(&self, batch: &mut UberBatch, vertex_id: Uuid, name: &str) {
+        batch.vertex_properties().remove(&self.key(vertex_id, name));
     }
 }
 
-pub struct EdgePropertyManager<'tree> {
+pub(crate) struct EdgePropertyManager<'tree> {
     pub tree: &'tree Tree,
 }
 
@@ -385,13 +549,13 @@ impl<'tree> EdgePropertyManager<'tree> {
         EdgePropertyManager { tree: &ds.edge_properties }
     }
 
-    fn key(&self, outbound_id: Uuid, t: &models::Type, inbound_id: Uuid, name: &str) -> Vec<u8> {
+    fn key(&self, outbound_id: Uuid, t: &models::Type, inbound_id: Uuid, name: &str) -> IVec {
         build(&[
             Component::Uuid(outbound_id),
             Component::Type(t),
             Component::Uuid(inbound_id),
             Component::UnsizedString(name),
-        ])
+        ]).into()
     }
 
     pub fn iterate_for_owner<'a>(
@@ -399,7 +563,7 @@ impl<'tree> EdgePropertyManager<'tree> {
         outbound_id: Uuid,
         t: &'a models::Type,
         inbound_id: Uuid,
-    ) -> Result<Box<dyn Iterator<Item = Result<EdgePropertyItem>> + 'a>> {
+    ) -> Box<dyn Iterator<Item = Result<EdgePropertyItem>> + 'a> {
         let prefix = build(&[
             Component::Uuid(outbound_id),
             Component::Type(t),
@@ -435,7 +599,7 @@ impl<'tree> EdgePropertyManager<'tree> {
             ))
         });
 
-        Ok(Box::new(mapped))
+        Box::new(mapped)
     }
 
     pub fn get(&self, outbound_id: Uuid, t: &models::Type, inbound_id: Uuid, name: &str) -> Result<Option<JsonValue>> {
@@ -457,12 +621,11 @@ impl<'tree> EdgePropertyManager<'tree> {
     ) -> Result<()> {
         let key = self.key(outbound_id, t, inbound_id, name);
         let value_json = serde_json::to_vec(value)?;
-        self.tree.insert(key.as_slice(), value_json.as_slice())?;
+        self.tree.insert(key, value_json.as_slice())?;
         Ok(())
     }
 
-    pub fn delete(&self, outbound_id: Uuid, t: &models::Type, inbound_id: Uuid, name: &str) -> Result<()> {
-        self.tree.remove(&self.key(outbound_id, t, inbound_id, name))?;
-        Ok(())
+    pub fn delete(&self, batch: &mut UberBatch, outbound_id: Uuid, t: &models::Type, inbound_id: Uuid, name: &str) {
+        batch.edge_properties().remove(&self.key(outbound_id, t, inbound_id, name));
     }
 }

--- a/lib/src/sledds/managers.rs
+++ b/lib/src/sledds/managers.rs
@@ -98,10 +98,9 @@ impl<'db> VertexManager<'db> {
         self.iterate(iter)
     }
 
-    pub fn create(&self, vertex: &models::Vertex) -> Result<()> {
+    pub fn create(&self, batch: &mut Batch, vertex: &models::Vertex) {
         let key = self.key(vertex.id);
-        self.db.insert(&key, build(&[Component::Type(&vertex.t)]))?;
-        Ok(())
+        batch.insert(&key, build(&[Component::Type(&vertex.t)]));
     }
 
     pub fn delete(&self, batch: &mut Batch, id: Uuid) -> Result<()> {
@@ -406,10 +405,10 @@ impl<'db> VertexPropertyManager<'db> {
         }
     }
 
-    pub fn set(&self, vertex_id: Uuid, name: &str, value: &JsonValue) -> Result<()> {
+    pub fn set(&self, batch: &mut Batch, vertex_id: Uuid, name: &str, value: &JsonValue) -> Result<()> {
         let key = self.key(vertex_id, name);
         let value_json = serde_json::to_vec(value)?;
-        self.db.insert(key, value_json.as_slice())?;
+        batch.insert(key, value_json.as_slice());
         Ok(())
     }
 
@@ -493,6 +492,7 @@ impl<'db> EdgePropertyManager<'db> {
 
     pub fn set(
         &self,
+        batch: &mut Batch,
         outbound_id: Uuid,
         t: &models::Type,
         inbound_id: Uuid,
@@ -501,7 +501,7 @@ impl<'db> EdgePropertyManager<'db> {
     ) -> Result<()> {
         let key = self.key(outbound_id, t, inbound_id, name);
         let value_json = serde_json::to_vec(value)?;
-        self.db.insert(key, value_json.as_slice())?;
+        batch.insert(key, value_json.as_slice());
         Ok(())
     }
 

--- a/lib/src/sledds/managers.rs
+++ b/lib/src/sledds/managers.rs
@@ -1,14 +1,20 @@
+// TODO:
+// - audit all lifetime uses and see if they can be simplified/removed
+// - audit all use of boxed dyn iters and see if they can be simplified
+
+use std::io::Cursor;
+use std::ops::Deref;
+use std::u8;
+
 use super::super::bytes::*;
 use crate::errors::Result;
 use crate::models;
+
 use chrono::offset::Utc;
 use chrono::DateTime;
 use serde_json::Value as JsonValue;
 use sled::Result as SledResult;
-use sled::{IVec, Iter as DbIterator, Tree, Batch, Transactional, Config, Db};
-use std::io::Cursor;
-use std::ops::Deref;
-use std::u8;
+use sled::{IVec, Iter as DbIterator, Batch, Db};
 use uuid::Uuid;
 
 pub type OwnedPropertyItem = ((Uuid, String), JsonValue);
@@ -45,162 +51,25 @@ impl SledConfig {
     }
 }
 
-/// The meat of a Sled datastore
-pub struct SledHolder {
-    pub(crate) db: Db,
-    pub(crate) vertices: Tree,
-    pub(crate) edges: Tree,
-    pub(crate) edge_ranges: Tree,
-    pub(crate) reversed_edge_ranges: Tree,
-    pub(crate) vertex_properties: Tree,
-    pub(crate) edge_properties: Tree,
+pub(crate) struct VertexManager<'db> {
+    pub db: &'db Db
 }
 
-impl<'ds> SledHolder {
-    /// The meat of a Sled datastore.
-    ///
-    /// # Arguments
-    /// * `path` - The file path to the Sled database.
-    /// * `config` - Sled options to pass in.
-    pub fn new(path: &str, config: SledConfig) -> Result<SledHolder> {
-        let mut sled_config = Config::default().path(path);
-
-        if config.use_compression {
-            sled_config = sled_config.use_compression(true);
-        }
-
-        if let Some(compression_factor) = config.compression_factor {
-            sled_config = sled_config.compression_factor(compression_factor);
-        }
-
-        let db = sled_config.open()?;
-
-        Ok(SledHolder {
-            vertices: db.open_tree("vertices")?,
-            edges: db.open_tree("edges")?,
-            edge_ranges: db.open_tree("edge_ranges")?,
-            reversed_edge_ranges: db.open_tree("reversed_edge_ranges")?,
-            vertex_properties: db.open_tree("vertex_properties")?,
-            edge_properties: db.open_tree("edge_properties")?,
-            db,
-        })
-    }
-}
-
-#[derive(Default)]
-pub(crate) struct UberBatch {
-    pub vertices: Option<Batch>,
-    pub edges: Option<Batch>,
-    pub edge_ranges: Option<Batch>,
-    pub reversed_edge_ranges: Option<Batch>,
-    pub vertex_properties: Option<Batch>,
-    pub edge_properties: Option<Batch>,
-}
-
-impl UberBatch {
-    pub(crate) fn vertices(&mut self) -> &mut Batch {
-        if self.vertices.is_none() {
-            self.vertices = Some(Batch::default());
-        }
-        self.vertices.as_mut().unwrap()
-    }
-
-    pub(crate) fn edges(&mut self) -> &mut Batch {
-        if self.edges.is_none() {
-            self.edges = Some(Batch::default());
-        }
-        self.edges.as_mut().unwrap()
-    }
-
-    pub(crate) fn edge_ranges(&mut self) -> &mut Batch {
-        if self.edge_ranges.is_none() {
-            self.edge_ranges = Some(Batch::default());
-        }
-        self.edge_ranges.as_mut().unwrap()
-    }
-
-    pub(crate) fn reversed_edge_ranges(&mut self) -> &mut Batch {
-        if self.reversed_edge_ranges.is_none() {
-            self.reversed_edge_ranges = Some(Batch::default());
-        }
-        self.reversed_edge_ranges.as_mut().unwrap()
-    }
-
-    pub(crate) fn vertex_properties(&mut self) -> &mut Batch {
-        if self.vertex_properties.is_none() {
-            self.vertex_properties = Some(Batch::default());
-        }
-        self.vertex_properties.as_mut().unwrap()
-    }
-
-    pub(crate) fn edge_properties(&mut self) -> &mut Batch {
-        if self.edge_properties.is_none() {
-            self.edge_properties = Some(Batch::default());
-        }
-        self.edge_properties.as_mut().unwrap()
-    }
-
-    pub(crate) fn apply(self, holder: &SledHolder) -> Result<()> {
-        // TODO: find a better way to do this that minimizes the number of
-        // transactions
-        let trees = (
-            &holder.vertices,
-            &holder.edges,
-            &holder.edge_ranges,
-            &holder.reversed_edge_ranges,
-            &holder.vertex_properties,
-            &holder.edge_properties,
-        );
-
-        trees.transaction(|(vertices_tree, edges_tree, edge_ranges_tree, reversed_edge_ranges_tree, vertex_properties_tree, edge_properties_tree)| {
-            if let Some(vertices_batch) = &self.vertices {
-                vertices_tree.apply_batch(&vertices_batch)?;
-            }
-            if let Some(edges_batch) = &self.edges {
-                edges_tree.apply_batch(&edges_batch)?;
-            }
-            if let Some(edge_ranges_batch) = &self.edge_ranges {
-                edge_ranges_tree.apply_batch(&edge_ranges_batch)?;
-            }
-            if let Some(reversed_edge_ranges_batch) = &self.reversed_edge_ranges {
-                reversed_edge_ranges_tree.apply_batch(&reversed_edge_ranges_batch)?;
-            }
-            if let Some(vertex_properties_batch) = &self.vertex_properties {
-                vertex_properties_tree.apply_batch(&vertex_properties_batch)?;
-            }
-            if let Some(edge_properties_batch) = &self.edge_properties {
-                edge_properties_tree.apply_batch(&edge_properties_batch)?;
-            }
-            Ok(())
-        })?;
-
-        Ok(())
-    }
-}
-
-pub(crate) struct VertexManager<'db: 'tree, 'tree> {
-    pub holder: &'db SledHolder,
-    pub tree: &'tree Tree,
-}
-
-impl<'db: 'tree, 'tree> VertexManager<'db, 'tree> {
-    pub fn new(ds: &'db SledHolder) -> Self {
-        VertexManager {
-            holder: ds,
-            tree: &ds.vertices,
-        }
+impl<'db> VertexManager<'db> {
+    pub fn new(db: &'db Db) -> Self {
+        VertexManager { db }
     }
 
     fn key(&self, id: Uuid) -> IVec {
-        build(&[Component::Uuid(id)]).into()
+        build(&[Component::AsciiChar('v'), Component::Uuid(id)]).into()
     }
 
     pub fn exists(&self, id: Uuid) -> Result<bool> {
-        Ok(self.tree.get(&self.key(id))?.is_some())
+        Ok(self.db.contains_key(&self.key(id))?)
     }
 
     pub fn get(&self, id: Uuid) -> Result<Option<models::Type>> {
-        match self.tree.get(&self.key(id))? {
+        match self.db.get(&self.key(id))? {
             Some(value_bytes) => {
                 let mut cursor = Cursor::new(value_bytes.deref());
                 Ok(Some(read_type(&mut cursor)))
@@ -214,8 +83,9 @@ impl<'db: 'tree, 'tree> VertexManager<'db, 'tree> {
             let (k, v) = item?;
 
             let id = {
-                debug_assert_eq!(k.len(), 16);
+                debug_assert_eq!(k.len(), 17);
                 let mut cursor = Cursor::new(k);
+                read_expected_char(&mut cursor, 'v');
                 read_uuid(&mut cursor)
             };
 
@@ -226,31 +96,31 @@ impl<'db: 'tree, 'tree> VertexManager<'db, 'tree> {
     }
 
     pub fn iterate_for_range<'a>(&'a self, id: Uuid) -> impl Iterator<Item = Result<VertexItem>> + 'a {
-        let low_key = build(&[Component::Uuid(id)]);
+        let low_key = build(&[Component::AsciiChar('v'), Component::Uuid(id)]);
         let low_key_bytes: &[u8] = low_key.as_ref();
-        let iter = self.tree.range(low_key_bytes..);
+        let iter = self.db.range(low_key_bytes..);
         self.iterate(iter)
     }
 
     pub fn create(&self, vertex: &models::Vertex) -> Result<()> {
         let key = self.key(vertex.id);
-        self.tree.insert(&key, build(&[Component::Type(&vertex.t)]))?;
+        self.db.insert(&key, build(&[Component::Type(&vertex.t)]))?;
         Ok(())
     }
 
-    pub fn delete(&self, batch: &mut UberBatch, id: Uuid) -> Result<()> {
-        batch.vertices().remove(&self.key(id));
+    pub fn delete(&self, batch: &mut Batch, id: Uuid) -> Result<()> {
+        batch.remove(&self.key(id));
 
-        let vertex_property_manager = VertexPropertyManager::new(&self.holder);
+        let vertex_property_manager = VertexPropertyManager::new(&self.db);
         for item in vertex_property_manager.iterate_for_owner(id) {
             let ((vertex_property_owner_id, vertex_property_name), _) = item?;
             vertex_property_manager.delete(batch, vertex_property_owner_id, &vertex_property_name[..]);
         }
 
-        let edge_manager = EdgeManager::new(&self.holder);
+        let edge_manager = EdgeManager::new(&self.db);
 
         {
-            let edge_range_manager = EdgeRangeManager::new(&self.holder);
+            let edge_range_manager = EdgeRangeManager::new(&self.db);
             for item in edge_range_manager.iterate_for_owner(id) {
                 let (edge_range_outbound_id, edge_range_t, edge_range_update_datetime, edge_range_inbound_id) = item?;
                 debug_assert_eq!(edge_range_outbound_id, id);
@@ -265,7 +135,7 @@ impl<'db: 'tree, 'tree> VertexManager<'db, 'tree> {
         }
 
         {
-            let reversed_edge_range_manager = EdgeRangeManager::new_reversed(&self.holder);
+            let reversed_edge_range_manager = EdgeRangeManager::new_reversed(&self.db);
             for item in reversed_edge_range_manager.iterate_for_owner(id) {
                 let (
                     reversed_edge_range_inbound_id,
@@ -287,21 +157,18 @@ impl<'db: 'tree, 'tree> VertexManager<'db, 'tree> {
     }
 }
 
-pub(crate) struct EdgeManager<'db: 'tree, 'tree> {
-    pub holder: &'db SledHolder,
-    pub tree: &'tree Tree,
+pub(crate) struct EdgeManager<'db> {
+    pub db: &'db Db
 }
 
-impl<'db, 'tree> EdgeManager<'db, 'tree> {
-    pub fn new(ds: &'db SledHolder) -> Self {
-        EdgeManager {
-            holder: ds,
-            tree: &ds.edges,
-        }
+impl<'db> EdgeManager<'db> {
+    pub fn new(db: &'db Db) -> Self {
+        EdgeManager { db }
     }
 
     fn key(&self, outbound_id: Uuid, t: &models::Type, inbound_id: Uuid) -> IVec {
         build(&[
+            Component::AsciiChar('e'),
             Component::Uuid(outbound_id),
             Component::Type(t),
             Component::Uuid(inbound_id),
@@ -309,7 +176,7 @@ impl<'db, 'tree> EdgeManager<'db, 'tree> {
     }
 
     pub fn get(&self, outbound_id: Uuid, t: &models::Type, inbound_id: Uuid) -> Result<Option<DateTime<Utc>>> {
-        match self.tree.get(self.key(outbound_id, t, inbound_id))? {
+        match self.db.get(self.key(outbound_id, t, inbound_id))? {
             Some(value_bytes) => {
                 let mut cursor = Cursor::new(value_bytes.deref());
                 Ok(Some(read_datetime(&mut cursor)))
@@ -320,14 +187,14 @@ impl<'db, 'tree> EdgeManager<'db, 'tree> {
 
     pub fn set(
         &self,
-        batch: &mut UberBatch,
+        batch: &mut Batch,
         outbound_id: Uuid,
         t: &models::Type,
         inbound_id: Uuid,
         new_update_datetime: DateTime<Utc>,
     ) -> Result<()> {
-        let edge_range_manager = EdgeRangeManager::new(&self.holder);
-        let reversed_edge_range_manager = EdgeRangeManager::new_reversed(&self.holder);
+        let edge_range_manager = EdgeRangeManager::new(&self.db);
+        let reversed_edge_range_manager = EdgeRangeManager::new_reversed(&self.db);
 
         if let Some(update_datetime) = self.get(outbound_id, t, inbound_id)? {
             edge_range_manager.delete(batch, outbound_id, t, update_datetime, inbound_id);
@@ -335,7 +202,7 @@ impl<'db, 'tree> EdgeManager<'db, 'tree> {
         }
 
         let key = self.key(outbound_id, t, inbound_id);
-        batch.edges().insert(key, build(&[Component::DateTime(new_update_datetime)]));
+        batch.insert(key, build(&[Component::DateTime(new_update_datetime)]));
         edge_range_manager.set(batch, outbound_id, t, new_update_datetime, inbound_id);
         reversed_edge_range_manager.set(batch, inbound_id, t, new_update_datetime, outbound_id);
         Ok(())
@@ -343,21 +210,21 @@ impl<'db, 'tree> EdgeManager<'db, 'tree> {
 
     pub fn delete(
         &self,
-        batch: &mut UberBatch,
+        batch: &mut Batch,
         outbound_id: Uuid,
         t: &models::Type,
         inbound_id: Uuid,
         update_datetime: DateTime<Utc>,
     ) -> Result<()> {
-        batch.edges().remove(&self.key(outbound_id, t, inbound_id));
+        batch.remove(&self.key(outbound_id, t, inbound_id));
 
-        let edge_range_manager = EdgeRangeManager::new(&self.holder);
+        let edge_range_manager = EdgeRangeManager::new(&self.db);
         edge_range_manager.delete(batch, outbound_id, t, update_datetime, inbound_id);
 
-        let reversed_edge_range_manager = EdgeRangeManager::new_reversed(&self.holder);
+        let reversed_edge_range_manager = EdgeRangeManager::new_reversed(&self.db);
         reversed_edge_range_manager.delete(batch, inbound_id, t, update_datetime, outbound_id);
 
-        let edge_property_manager = EdgePropertyManager::new(&self.holder);
+        let edge_property_manager = EdgePropertyManager::new(&self.db);
         for item in edge_property_manager.iterate_for_owner(outbound_id, t, inbound_id) {
             let ((edge_property_outbound_id, edge_property_t, edge_property_inbound_id, edge_property_name), _) = item?;
             edge_property_manager.delete(
@@ -372,25 +239,31 @@ impl<'db, 'tree> EdgeManager<'db, 'tree> {
     }
 }
 
-pub(crate) struct EdgeRangeManager<'tree> {
-    pub tree: &'tree Tree,
+pub(crate) struct EdgeRangeManager<'db> {
+    pub db: &'db Db,
     reversed: bool
 }
 
-impl<'tree> EdgeRangeManager<'tree> {
-    pub fn new<'db: 'tree>(ds: &'db SledHolder) -> Self {
-        EdgeRangeManager { tree: &ds.edge_ranges, reversed: false }
+impl<'db> EdgeRangeManager<'db> {
+    pub fn new(db: &'db Db) -> Self {
+        EdgeRangeManager { db, reversed: false }
     }
 
-    pub fn new_reversed<'db: 'tree>(ds: &'db SledHolder) -> Self {
-        EdgeRangeManager {
-            tree: &ds.reversed_edge_ranges,
-            reversed: true,
+    pub fn new_reversed(db: &'db Db) -> Self {
+        EdgeRangeManager { db, reversed: true }
+    }
+
+    fn prefix(&self) -> char {
+        if self.reversed {
+            '<'
+        } else {
+            '>'
         }
     }
 
     fn key(&self, first_id: Uuid, t: &models::Type, update_datetime: DateTime<Utc>, second_id: Uuid) -> IVec {
         build(&[
+            Component::AsciiChar(self.prefix()),
             Component::Uuid(first_id),
             Component::Type(t),
             Component::DateTime(update_datetime),
@@ -398,15 +271,16 @@ impl<'tree> EdgeRangeManager<'tree> {
         ]).into()
     }
 
-    fn iterate<'it>(
+    fn iterate(
         &self,
         iterator: DbIterator,
         prefix: Vec<u8>,
-    ) -> impl Iterator<Item = Result<EdgeRangeItem>> + 'it {
+    ) -> impl Iterator<Item = Result<EdgeRangeItem>> + '_ {
         let filtered = take_while_prefixed(iterator, prefix);
         filtered.map(move |item| -> Result<EdgeRangeItem> {
             let (k, _) = item?;
             let mut cursor = Cursor::new(k);
+            read_expected_char(&mut cursor, self.prefix());
             let first_id = read_uuid(&mut cursor);
             let t = read_type(&mut cursor);
             let update_datetime = read_datetime(&mut cursor);
@@ -424,16 +298,16 @@ impl<'tree> EdgeRangeManager<'tree> {
         match t {
             Some(t) => {
                 let high = high.unwrap_or_else(|| *MAX_DATETIME);
-                let prefix = build(&[Component::Uuid(id), Component::Type(t)]);
-                let low_key = build(&[Component::Uuid(id), Component::Type(t), Component::DateTime(high)]);
+                let prefix = build(&[Component::AsciiChar(self.prefix()), Component::Uuid(id), Component::Type(t)]);
+                let low_key = build(&[Component::AsciiChar(self.prefix()), Component::Uuid(id), Component::Type(t), Component::DateTime(high)]);
                 let low_key_bytes: &[u8] = low_key.as_ref();
-                let iterator = self.tree.range(low_key_bytes..);
+                let iterator = self.db.range(low_key_bytes..);
                 Box::new(self.iterate(iterator, prefix))
             }
             None => {
-                let prefix = build(&[Component::Uuid(id)]);
+                let prefix = build(&[Component::AsciiChar(self.prefix()), Component::Uuid(id)]);
                 let prefix_bytes: &[u8] = prefix.as_ref();
-                let iterator = self.tree.range(prefix_bytes..);
+                let iterator = self.db.range(prefix_bytes..);
                 let mapped = self.iterate(iterator, prefix);
 
                 if let Some(high) = high {
@@ -460,57 +334,58 @@ impl<'tree> EdgeRangeManager<'tree> {
         &'trans self,
         id: Uuid,
     ) -> impl Iterator<Item = Result<EdgeRangeItem>> + 'iter {
-        let prefix: Vec<u8> = build(&[Component::Uuid(id)]);
-        let iterator = self.tree.scan_prefix(&prefix);
+        let prefix: Vec<u8> = build(&[Component::AsciiChar(self.prefix()), Component::Uuid(id)]);
+        let iterator = self.db.scan_prefix(&prefix);
         self.iterate(iterator, prefix)
     }
 
-    pub fn set(&self, batch: &mut UberBatch, first_id: Uuid, t: &models::Type, update_datetime: DateTime<Utc>, second_id: Uuid) {
+    pub fn set(&self, batch: &mut Batch, first_id: Uuid, t: &models::Type, update_datetime: DateTime<Utc>, second_id: Uuid) {
         let key = self.key(first_id, t, update_datetime, second_id);
         if self.reversed {
-            batch.reversed_edge_ranges().insert(&key, &[]);
+            batch.insert(&key, &[]);
         } else {
-            batch.edge_ranges().insert(&key, &[]);
+            batch.insert(&key, &[]);
         }
     }
 
     pub fn delete(
         &self,
-        batch: &mut UberBatch,
+        batch: &mut Batch,
         first_id: Uuid,
         t: &models::Type,
         update_datetime: DateTime<Utc>,
         second_id: Uuid,
     ) {
         if self.reversed {
-            batch.reversed_edge_ranges().remove(&self.key(first_id, t, update_datetime, second_id));
+            batch.remove(&self.key(first_id, t, update_datetime, second_id));
         } else {
-            batch.edge_ranges().remove(&self.key(first_id, t, update_datetime, second_id));
+            batch.remove(&self.key(first_id, t, update_datetime, second_id));
         }
     }
 }
 
-pub(crate) struct VertexPropertyManager<'tree> {
-    pub tree: &'tree Tree,
+pub(crate) struct VertexPropertyManager<'db> {
+    pub db: &'db Db,
 }
 
-impl<'tree> VertexPropertyManager<'tree> {
-    pub fn new<'db: 'tree>(ds: &'db SledHolder) -> Self {
-        VertexPropertyManager { tree: &ds.vertex_properties }
+impl<'db> VertexPropertyManager<'db> {
+    pub fn new(db: &'db Db) -> Self {
+        VertexPropertyManager { db }
     }
 
 
     fn key(&self, vertex_id: Uuid, name: &str) -> IVec {
-        build(&[Component::Uuid(vertex_id), Component::UnsizedString(name)]).into()
+        build(&[Component::AsciiChar('1'), Component::Uuid(vertex_id), Component::UnsizedString(name)]).into()
     }
 
     pub fn iterate_for_owner(&self, vertex_id: Uuid) -> impl Iterator<Item = Result<OwnedPropertyItem>> + '_ {
-        let prefix = build(&[Component::Uuid(vertex_id)]);
-        let iterator = self.tree.scan_prefix(&prefix);
+        let prefix = build(&[Component::AsciiChar('1'), Component::Uuid(vertex_id)]);
+        let iterator = self.db.scan_prefix(&prefix);
 
         iterator.map(move |item| -> Result<OwnedPropertyItem> {
             let (k, v) = item?;
             let mut cursor = Cursor::new(k);
+            read_expected_char(&mut cursor, '1');
             let owner_id = read_uuid(&mut cursor);
             debug_assert_eq!(vertex_id, owner_id);
             let name = read_unsized_string(&mut cursor);
@@ -522,7 +397,7 @@ impl<'tree> VertexPropertyManager<'tree> {
     pub fn get(&self, vertex_id: Uuid, name: &str) -> Result<Option<JsonValue>> {
         let key = self.key(vertex_id, name);
 
-        match self.tree.get(&key)? {
+        match self.db.get(&key)? {
             Some(value_bytes) => Ok(Some(serde_json::from_slice(&value_bytes)?)),
             None => Ok(None),
         }
@@ -531,26 +406,27 @@ impl<'tree> VertexPropertyManager<'tree> {
     pub fn set(&self, vertex_id: Uuid, name: &str, value: &JsonValue) -> Result<()> {
         let key = self.key(vertex_id, name);
         let value_json = serde_json::to_vec(value)?;
-        self.tree.insert(key, value_json.as_slice())?;
+        self.db.insert(key, value_json.as_slice())?;
         Ok(())
     }
 
-    pub fn delete(&self, batch: &mut UberBatch, vertex_id: Uuid, name: &str) {
-        batch.vertex_properties().remove(&self.key(vertex_id, name));
+    pub fn delete(&self, batch: &mut Batch, vertex_id: Uuid, name: &str) {
+        batch.remove(&self.key(vertex_id, name));
     }
 }
 
-pub(crate) struct EdgePropertyManager<'tree> {
-    pub tree: &'tree Tree,
+pub(crate) struct EdgePropertyManager<'db> {
+    pub db: &'db Db
 }
 
-impl<'tree> EdgePropertyManager<'tree> {
-    pub fn new<'db: 'tree>(ds: &'db SledHolder) -> Self {
-        EdgePropertyManager { tree: &ds.edge_properties }
+impl<'db> EdgePropertyManager<'db> {
+    pub fn new(db: &'db Db) -> Self {
+        EdgePropertyManager { db }
     }
 
     fn key(&self, outbound_id: Uuid, t: &models::Type, inbound_id: Uuid, name: &str) -> IVec {
         build(&[
+            Component::AsciiChar('2'),
             Component::Uuid(outbound_id),
             Component::Type(t),
             Component::Uuid(inbound_id),
@@ -565,16 +441,18 @@ impl<'tree> EdgePropertyManager<'tree> {
         inbound_id: Uuid,
     ) -> Box<dyn Iterator<Item = Result<EdgePropertyItem>> + 'a> {
         let prefix = build(&[
+            Component::AsciiChar('2'),
             Component::Uuid(outbound_id),
             Component::Type(t),
             Component::Uuid(inbound_id),
         ]);
 
-        let iterator = self.tree.scan_prefix(&prefix);
+        let iterator = self.db.scan_prefix(&prefix);
 
         let mapped = iterator.map(move |item| -> Result<EdgePropertyItem> {
             let (k, v) = item?;
             let mut cursor = Cursor::new(k);
+            read_expected_char(&mut cursor, '2');
 
             let edge_property_outbound_id = read_uuid(&mut cursor);
             debug_assert_eq!(edge_property_outbound_id, outbound_id);
@@ -605,7 +483,7 @@ impl<'tree> EdgePropertyManager<'tree> {
     pub fn get(&self, outbound_id: Uuid, t: &models::Type, inbound_id: Uuid, name: &str) -> Result<Option<JsonValue>> {
         let key = self.key(outbound_id, t, inbound_id, name);
 
-        match self.tree.get(&key)? {
+        match self.db.get(&key)? {
             Some(ref value_bytes) => Ok(Some(serde_json::from_slice(&value_bytes)?)),
             None => Ok(None),
         }
@@ -621,11 +499,11 @@ impl<'tree> EdgePropertyManager<'tree> {
     ) -> Result<()> {
         let key = self.key(outbound_id, t, inbound_id, name);
         let value_json = serde_json::to_vec(value)?;
-        self.tree.insert(key, value_json.as_slice())?;
+        self.db.insert(key, value_json.as_slice())?;
         Ok(())
     }
 
-    pub fn delete(&self, batch: &mut UberBatch, outbound_id: Uuid, t: &models::Type, inbound_id: Uuid, name: &str) {
-        batch.edge_properties().remove(&self.key(outbound_id, t, inbound_id, name));
+    pub fn delete(&self, batch: &mut Batch, outbound_id: Uuid, t: &models::Type, inbound_id: Uuid, name: &str) {
+        batch.remove(&self.key(outbound_id, t, inbound_id, name));
     }
 }

--- a/lib/src/sledds/managers.rs
+++ b/lib/src/sledds/managers.rs
@@ -40,10 +40,10 @@ impl SledConfig {
     /// * `factor` - The zstd compression factor to use. If unspecified, this
     ///   will default to 5.
     pub fn with_compression(factor: Option<i32>) -> SledConfig {
-        return SledConfig {
+        Self {
             use_compression: true,
             compression_factor: factor,
-        };
+        }
     }
 }
 
@@ -337,11 +337,7 @@ impl<'db> EdgeRangeManager<'db> {
 
     pub fn set(&self, batch: &mut Batch, first_id: Uuid, t: &models::Type, update_datetime: DateTime<Utc>, second_id: Uuid) {
         let key = self.key(first_id, t, update_datetime, second_id);
-        if self.reversed {
-            batch.insert(&key, &[]);
-        } else {
-            batch.insert(&key, &[]);
-        }
+        batch.insert(&key, &[]);
     }
 
     pub fn delete(
@@ -352,11 +348,7 @@ impl<'db> EdgeRangeManager<'db> {
         update_datetime: DateTime<Utc>,
         second_id: Uuid,
     ) {
-        if self.reversed {
-            batch.remove(&self.key(first_id, t, update_datetime, second_id));
-        } else {
-            batch.remove(&self.key(first_id, t, update_datetime, second_id));
-        }
+        batch.remove(&self.key(first_id, t, update_datetime, second_id));
     }
 }
 

--- a/lib/src/sledds/mod.rs
+++ b/lib/src/sledds/mod.rs
@@ -3,7 +3,8 @@
 mod datastore;
 mod managers;
 
-pub use self::datastore::{SledConfig, SledDatastore, SledTransaction};
+pub use self::datastore::{SledDatastore, SledTransaction};
+pub use self::managers::SledConfig;
 
 mod normal_config {
     #[cfg(feature = "bench-suite")]
@@ -24,19 +25,15 @@ mod normal_config {
 mod compression_config {
     #[cfg(feature = "bench-suite")]
     full_bench_impl!({
-        use super::SledConfig;
+        use super::{SledDatastore, SledConfig};
         use crate::util::generate_temporary_path;
-        SledConfig::with_compression(None)
-            .open(&generate_temporary_path())
-            .unwrap()
+        SledDatastore::new_with_config(&generate_temporary_path(), SledConfig::with_compression(None)).unwrap()
     });
 
     #[cfg(feature = "test-suite")]
     full_test_impl!({
-        use super::SledConfig;
+        use super::{SledDatastore, SledConfig};
         use crate::util::generate_temporary_path;
-        SledConfig::with_compression(None)
-            .open(&generate_temporary_path())
-            .unwrap()
+        SledDatastore::new_with_config(&generate_temporary_path(), SledConfig::with_compression(None)).unwrap()
     });
 }

--- a/lib/src/sledds/mod.rs
+++ b/lib/src/sledds/mod.rs
@@ -25,14 +25,14 @@ mod normal_config {
 mod compression_config {
     #[cfg(feature = "bench-suite")]
     full_bench_impl!({
-        use super::{SledDatastore, SledConfig};
+        use super::{SledConfig, SledDatastore};
         use crate::util::generate_temporary_path;
         SledDatastore::new_with_config(&generate_temporary_path(), SledConfig::with_compression(None)).unwrap()
     });
 
     #[cfg(feature = "test-suite")]
     full_test_impl!({
-        use super::{SledDatastore, SledConfig};
+        use super::{SledConfig, SledDatastore};
         use crate::util::generate_temporary_path;
         SledDatastore::new_with_config(&generate_temporary_path(), SledConfig::with_compression(None)).unwrap()
     });


### PR DESCRIPTION
Within sled, this updates all operations involving more than one update to execute atomically. As a result, the sled datastore has roughly the same safety guarantees as the rocksdb datastore.

Closes #98 