### PR TITLE
Add cli args

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,32 +33,38 @@ This should start an in-memory-only datastore, where all work will be wiped out 
 
 By default, IndraDB starts an in-memory datastore that does not persist to
 disk. This is useful for kicking the tires. If you want to use the in-memory
-datastore, do not set the `database` flag, or just set it to `memory://`. e.g.:
-`indradb --database=memory://`
+datastore, simply start up an instance. e.g.: 
+```bash
+indradb [options] [subcommands]
+```
+
 
 ### RocksDB
 
-If you want to use the rocksdb-backed datastore, set the `database`
-CLI flag; e.g.: `indradb --database=rocksdb://database.rdb`.
+If you want to use the rocksdb-backed datastore, use the `rocksdb` subcommand. Supply the rocksdb database url via the command line. e.g
+```bash
+indradb rocksdb rocksdb://database.rdb [options]
+```
 
 ### Sled
 
-If you want to a datastore based on [Sled](http://sled.rs/), set the `database`
-environment variable; e.g.: `indradb --database=sled://sled_dir`. If `sled_dir`
-does not exist, it will be created.
+If you want to a datastore based on [Sled](http://sled.rs/), use the `sled` subcommand; e.g. 
+```bash
+indradb sled sled://sled_dir [options]
+```
+ If `sled_dir` does not exist, it will be created.
 
 # CLI Options
 Applications are configured via CLI arguments:
 
 ```
-  -d, --database string          The connection string to the underlying database.
   -p, --port                     The port to run the server on. Defaults to 27615.
 
-  [RocksDB]
+  [RocksDB options]
   --max_open_files               Sets the number of maximum open files to have open in RocksDB.
   --bulk_load_opt   			 If set to true, RocksDB will be configured to optimize for bulk loading of data, likely at the detriment of any other kind of workload.
 
-  [Sled]
+  [Sled options]
   --sled_compression			 If set to true, compression will be enabled at the default zstd factor of 5. If set to an integer, compression will be enabled at the zstd specified factor.
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ indradb [options] [subcommands]
 
 If you want to use the rocksdb-backed datastore, use the `rocksdb` subcommand. Supply the rocksdb database url via the command line. e.g
 ```bash
-indradb rocksdb rocksdb://database.rdb [options]
+indradb rocksdb /path/to/rocksdb.rdb [options]
 ```
 
 ### Sled
 
 If you want to a datastore based on [Sled](http://sled.rs/), use the `sled` subcommand; e.g. 
 ```bash
-indradb sled sled://sled_dir [options]
+indradb sled sled_dir [options]
 ```
  If `sled_dir` does not exist, it will be created.
 

--- a/README.md
+++ b/README.md
@@ -33,37 +33,34 @@ This should start an in-memory-only datastore, where all work will be wiped out 
 
 By default, IndraDB starts an in-memory datastore that does not persist to
 disk. This is useful for kicking the tires. If you want to use the in-memory
-datastore, do not set the `DATABASE_URL`, or just set it to `memory://`. e.g.:
-`DATABASE_URL=memory:// indradb`
+datastore, do not set the `database` flag, or just set it to `memory://`. e.g.:
+`indradb --database=memory://`
 
 ### RocksDB
 
-If you want to use the rocksdb-backed datastore, set the `DATABASE_URL`
-environment variable; e.g.: `DATABASE_URL=rocksdb://database.rdb indradb`.
+If you want to use the rocksdb-backed datastore, set the `database`
+CLI flag; e.g.: `indradb --database=rocksdb://database.rdb`.
 
 ### Sled
 
-If you want to a datastore based on [Sled](http://sled.rs/), set the `DATABASE_URL`
-environment variable; e.g.: `DATABASE_URL=sled://sled_dir indradb`. If `sled_dir`
+If you want to a datastore based on [Sled](http://sled.rs/), set the `database`
+environment variable; e.g.: `indradb --database=sled://sled_dir`. If `sled_dir`
 does not exist, it will be created.
 
-## Environment variables
+# CLI Options
+Applications are configured via CLI arguments:
 
-Applications are configured via environment variables:
+```
+  -d, --database string          The connection string to the underlying database.
+  -p, --port                     The port to run the server on. Defaults to 27615.
 
-* `DATABASE_URL`: The connection string to the underlying database.
-* `PORT`: The port to run the server on. Defaults to `27615`.
+  [RocksDB]
+  --max_open_files               Sets the number of maximum open files to have open in RocksDB.
+  --bulk_load_opt   			 If set to true, RocksDB will be configured to optimize for bulk loading of data, likely at the detriment of any other kind of workload.
 
-Additional environment variables available when using the RocksDB datastore:
-
-* `ROCKSDB_MAX_OPEN_FILES`: Sets the number of maximum open files to have open in RocksDB.
-* `ROCKSDB_BULK_LOAD_OPTIMIZED`: If set to `true`, RocksDB will be configured to optimize for bulk loading of data, likely at the detriment of any other kind of workload.
-
-Additional environment variables available when using the Sled datastore:
-
-* `SLED_COMPRESSION`: If set to `true`, compression will be enabled at the
-default zstd factor of 5. If set to an integer, compression will be enabled at
-the zstd specified factor.
+  [Sled]
+  --sled_compression			 If set to true, compression will be enabled at the default zstd factor of 5. If set to an integer, compression will be enabled at the zstd specified factor.
+```
 
 ## Install from source
 

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -35,6 +35,7 @@ futures = "0.3.5"
 async-std = { version = "1.6.4", features = ["unstable"] }
 num_cpus = "1.13.0"
 chrono = "0.4.15"
+clap = "2.33.3"
 
 [dependencies.indradb-lib]
 path = "../lib"

--- a/bin/src/server/cli.rs
+++ b/bin/src/server/cli.rs
@@ -3,13 +3,20 @@ use indradb::SledConfig;
 
 pub struct CliArgs {
     pub port: u16,
-    pub datastore_args: CliDatastoreArgs
+    pub datastore_args: CliDatastoreArgs,
 }
 
 pub enum CliDatastoreArgs {
     Memory,
-    Rocksdb { path: String, max_open_files: i32, bulk_load_optimized: bool },
-    Sled { path: String, sled_config: SledConfig }
+    Rocksdb {
+        path: String,
+        max_open_files: i32,
+        bulk_load_optimized: bool,
+    },
+    Sled {
+        path: String,
+        sled_config: SledConfig,
+    },
 }
 
 const PORT: &str = "PORT";
@@ -65,23 +72,23 @@ pub fn parse_cli_args() -> CliArgs {
         .subcommand(sled_subcommand)
         .arg(&port)
         .get_matches();
-        
+
     let mut args = CliArgs {
         port: match matches.value_of(PORT) {
             Some(value) => value.parse::<u16>().expect("Could not parse argument `port`"),
             None => DEFAULT_PORT,
         },
-        datastore_args: CliDatastoreArgs::Memory
+        datastore_args: CliDatastoreArgs::Memory,
     };
 
-    if let Some(matches) = matches.subcommand_matches("rocksdb") {  
+    if let Some(matches) = matches.subcommand_matches("rocksdb") {
         args.datastore_args = CliDatastoreArgs::Rocksdb {
             path: String::from(matches.value_of(DATABASE_PATH).unwrap()),
             max_open_files: matches.value_of(ROCKSDB_MAX_OPEN_FILES).unwrap().parse::<i32>().expect(
                 "Could not parse argument `max_open_files`: must be an \
                  i32",
             ),
-            bulk_load_optimized: matches.value_of(ROCKSDB_BULK_LOAD_OPTIMIZED).unwrap() == "true"
+            bulk_load_optimized: matches.value_of(ROCKSDB_BULK_LOAD_OPTIMIZED).unwrap() == "true",
         }
     }
 
@@ -92,16 +99,14 @@ pub fn parse_cli_args() -> CliArgs {
             sled_config: match sled_compression {
                 "true" => indradb::SledConfig::with_compression(None),
                 "false" => indradb::SledConfig::default(),
-                _ => {
-                    indradb::SledConfig::with_compression(Some(
-                        sled_compression
+                _ => indradb::SledConfig::with_compression(Some(
+                    sled_compression
                         .parse::<i32>()
-                        .expect("Could not parse argument `sled_compression`: must be a bool or i32")
-                    ))
-                }
-            }
+                        .expect("Could not parse argument `sled_compression`: must be a bool or i32"),
+                )),
+            },
         }
     }
-    
+
     args
 }

--- a/bin/src/server/cli.rs
+++ b/bin/src/server/cli.rs
@@ -1,0 +1,107 @@
+use clap::{App, Arg, SubCommand};
+
+pub struct CliArgs {
+    pub port: u16,
+    pub database_url: String,
+    pub max_open_files: Option<i32>,
+    pub bulk_load_opt: Option<bool>,
+    pub sled_compression: Option<String>,
+}
+
+const PORT: &str = "PORT";
+const DATABASE_URL: &str = "DATABASE_URL";
+const ROCKSDB_MAX_OPEN_FILES: &str = "ROCKSDB_MAX_OPEN_FILES";
+const ROCKSDB_BULK_LOAD_OPTIMIZED: &str = "ROCKSDB_BULK_LOAD_OPTIMIZED";
+const SLED_COMPRESSION: &str = "SLED_COMPRESSION";
+
+const DEFAULT_PORT: u16 = 27615;
+
+pub fn parse_cli_args() -> CliArgs {
+    let database_url_argument = Arg::with_name(DATABASE_URL)
+        .help("Database url")
+        .required(true)
+        .default_value("memory://")
+        .index(1);
+    let port = Arg::with_name(PORT)
+        .short("p")
+        .long("port")
+        .value_name(PORT)
+        .help("The port to run the server on. Defaults to 27615")
+        .takes_value(true)
+        .default_value("27615");
+    let rocksdb_subcommand = SubCommand::with_name("rocksdb")
+        .about("Start an indradb instance backed by rocksdb")
+        .arg(&database_url_argument)
+        .arg(Arg::with_name(ROCKSDB_MAX_OPEN_FILES)
+            .long("max_open_files")
+            .value_name(ROCKSDB_MAX_OPEN_FILES)
+            .help("Sets the number of maximum open files to have open in RocksDB.")
+            .takes_value(true)
+            .default_value("512"))
+        .arg(Arg::with_name(ROCKSDB_BULK_LOAD_OPTIMIZED)
+            .long("bulk_load_opt")
+            .value_name(ROCKSDB_BULK_LOAD_OPTIMIZED)
+            .help("If set to true, RocksDB will be configured to optimize for bulk loading of data, likely at the detriment of any other kind of workload.")
+            .takes_value(true)
+            .default_value(""));
+
+    let sled_subcommand = SubCommand::with_name("sled")
+        .about("Start an indradb instance backed by sled")
+        .arg(&database_url_argument)
+        .arg(Arg::with_name(SLED_COMPRESSION)
+            .long("sled_compression")
+            .value_name(SLED_COMPRESSION)
+            .help("If set to true, compression will be enabled at the default zstd factor of 5. If set to an integer, compression will be enabled at the zstd specified factor.")
+            .takes_value(true)
+            .default_value(""));
+
+    let matches = App::new("Indra DB")
+        .version("1.2.0")
+        .about("Indra DB server")
+        .subcommand(rocksdb_subcommand)
+        .subcommand(sled_subcommand)
+        .arg(&port)
+        .get_matches();
+
+    let mut args = CliArgs {
+        port: match matches.value_of(PORT) {
+            Some(value) => value.parse::<u16>().expect("Could not parse argument `port`"),
+            None => DEFAULT_PORT,
+        },
+        database_url: String::from("memory://"),
+        max_open_files: None,
+        bulk_load_opt: None,
+        sled_compression: None,
+    };
+
+    if let Some(matches) = matches.subcommand_matches("rocksdb") {
+        if let Some(url) = matches.value_of(DATABASE_URL) {
+            args.database_url = String::from(url)
+        }
+
+        args.max_open_files = match matches.value_of(ROCKSDB_MAX_OPEN_FILES) {
+            Some(value) => Some(value.parse::<i32>().expect(
+                "Could not parse argument `max_open_files`: must be an \
+                 i32",
+            )),
+            None => None,
+        };
+
+        args.bulk_load_opt = match matches.value_of(ROCKSDB_BULK_LOAD_OPTIMIZED) {
+            Some(value) => Some(value == "true"),
+            None => None,
+        };
+    }
+
+    if let Some(matches) = matches.subcommand_matches("sled") {
+        if let Some(url) = matches.value_of(DATABASE_URL) {
+            args.database_url = String::from(url)
+        }
+        args.sled_compression = match matches.value_of(SLED_COMPRESSION) {
+            Some(value) => Some(String::from(value)),
+            None => None,
+        };
+    }
+
+    args
+}

--- a/bin/src/server/cli.rs
+++ b/bin/src/server/cli.rs
@@ -1,15 +1,19 @@
 use clap::{App, Arg, SubCommand};
+use indradb::SledConfig;
 
 pub struct CliArgs {
     pub port: u16,
-    pub database_url: String,
-    pub max_open_files: Option<i32>,
-    pub bulk_load_opt: Option<bool>,
-    pub sled_compression: Option<String>,
+    pub datastore_args: CliDatastoreArgs
+}
+
+pub enum CliDatastoreArgs {
+    Memory,
+    Rocksdb { path: String, max_open_files: i32, bulk_load_optimized: bool },
+    Sled { path: String, sled_config: SledConfig }
 }
 
 const PORT: &str = "PORT";
-const DATABASE_URL: &str = "DATABASE_URL";
+const DATABASE_PATH: &str = "DATABASE_PATH";
 const ROCKSDB_MAX_OPEN_FILES: &str = "ROCKSDB_MAX_OPEN_FILES";
 const ROCKSDB_BULK_LOAD_OPTIMIZED: &str = "ROCKSDB_BULK_LOAD_OPTIMIZED";
 const SLED_COMPRESSION: &str = "SLED_COMPRESSION";
@@ -17,10 +21,9 @@ const SLED_COMPRESSION: &str = "SLED_COMPRESSION";
 const DEFAULT_PORT: u16 = 27615;
 
 pub fn parse_cli_args() -> CliArgs {
-    let database_url_argument = Arg::with_name(DATABASE_URL)
+    let database_path_argument = Arg::with_name(DATABASE_PATH)
         .help("Database url")
         .required(true)
-        .default_value("memory://")
         .index(1);
     let port = Arg::with_name(PORT)
         .short("p")
@@ -31,7 +34,7 @@ pub fn parse_cli_args() -> CliArgs {
         .default_value("27615");
     let rocksdb_subcommand = SubCommand::with_name("rocksdb")
         .about("Start an indradb instance backed by rocksdb")
-        .arg(&database_url_argument)
+        .arg(&database_path_argument)
         .arg(Arg::with_name(ROCKSDB_MAX_OPEN_FILES)
             .long("max_open_files")
             .value_name(ROCKSDB_MAX_OPEN_FILES)
@@ -43,17 +46,17 @@ pub fn parse_cli_args() -> CliArgs {
             .value_name(ROCKSDB_BULK_LOAD_OPTIMIZED)
             .help("If set to true, RocksDB will be configured to optimize for bulk loading of data, likely at the detriment of any other kind of workload.")
             .takes_value(true)
-            .default_value(""));
+            .default_value("false"));
 
     let sled_subcommand = SubCommand::with_name("sled")
         .about("Start an indradb instance backed by sled")
-        .arg(&database_url_argument)
+        .arg(&database_path_argument)
         .arg(Arg::with_name(SLED_COMPRESSION)
-            .long("sled_compression")
+            .long("compression")
             .value_name(SLED_COMPRESSION)
             .help("If set to true, compression will be enabled at the default zstd factor of 5. If set to an integer, compression will be enabled at the zstd specified factor.")
             .takes_value(true)
-            .default_value(""));
+            .default_value("false"));
 
     let matches = App::new("Indra DB")
         .version("1.2.0")
@@ -62,46 +65,43 @@ pub fn parse_cli_args() -> CliArgs {
         .subcommand(sled_subcommand)
         .arg(&port)
         .get_matches();
-
+        
     let mut args = CliArgs {
         port: match matches.value_of(PORT) {
             Some(value) => value.parse::<u16>().expect("Could not parse argument `port`"),
             None => DEFAULT_PORT,
         },
-        database_url: String::from("memory://"),
-        max_open_files: None,
-        bulk_load_opt: None,
-        sled_compression: None,
+        datastore_args: CliDatastoreArgs::Memory
     };
 
-    if let Some(matches) = matches.subcommand_matches("rocksdb") {
-        if let Some(url) = matches.value_of(DATABASE_URL) {
-            args.database_url = String::from(url)
-        }
-
-        args.max_open_files = match matches.value_of(ROCKSDB_MAX_OPEN_FILES) {
-            Some(value) => Some(value.parse::<i32>().expect(
+    if let Some(matches) = matches.subcommand_matches("rocksdb") {  
+        args.datastore_args = CliDatastoreArgs::Rocksdb {
+            path: String::from(matches.value_of(DATABASE_PATH).unwrap()),
+            max_open_files: matches.value_of(ROCKSDB_MAX_OPEN_FILES).unwrap().parse::<i32>().expect(
                 "Could not parse argument `max_open_files`: must be an \
                  i32",
-            )),
-            None => None,
-        };
-
-        args.bulk_load_opt = match matches.value_of(ROCKSDB_BULK_LOAD_OPTIMIZED) {
-            Some(value) => Some(value == "true"),
-            None => None,
-        };
+            ),
+            bulk_load_optimized: matches.value_of(ROCKSDB_BULK_LOAD_OPTIMIZED).unwrap() == "true"
+        }
     }
 
     if let Some(matches) = matches.subcommand_matches("sled") {
-        if let Some(url) = matches.value_of(DATABASE_URL) {
-            args.database_url = String::from(url)
+        let sled_compression = matches.value_of(SLED_COMPRESSION).unwrap();
+        args.datastore_args = CliDatastoreArgs::Sled {
+            path: String::from(matches.value_of(DATABASE_PATH).unwrap()),
+            sled_config: match sled_compression {
+                "true" => indradb::SledConfig::with_compression(None),
+                "false" => indradb::SledConfig::default(),
+                _ => {
+                    indradb::SledConfig::with_compression(Some(
+                        sled_compression
+                        .parse::<i32>()
+                        .expect("Could not parse argument `sled_compression`: must be a bool or i32")
+                    ))
+                }
+            }
         }
-        args.sled_compression = match matches.value_of(SLED_COMPRESSION) {
-            Some(value) => Some(String::from(value)),
-            None => None,
-        };
     }
-
+    
     args
 }

--- a/bin/src/server/errors.rs
+++ b/bin/src/server/errors.rs
@@ -6,8 +6,6 @@ pub enum Error {
     Io { inner: io::Error },
     #[fail(display = "could not parse address binding")]
     CouldNotParseBinding,
-    #[fail(display = "could not parse database URL")]
-    CouldNotParseDatabaseURL,
 }
 
 impl From<io::Error> for Error {

--- a/bin/src/server/main.rs
+++ b/bin/src/server/main.rs
@@ -1,24 +1,66 @@
 #[macro_use]
 extern crate failure;
+extern crate clap;
 
 mod errors;
 
-use std::env;
 use std::net::ToSocketAddrs;
 
 use async_std::net::TcpListener;
+use clap::{App, Arg};
 use futures::executor::LocalPool;
 
 const DEFAULT_PORT: u16 = 27615;
 
+const PORT: &str = "PORT";
+const DATABASE_URL: &str = "DATABASE_URL";
+const ROCKSDB_MAX_OPEN_FILES: &str = "ROCKSDB_MAX_OPEN_FILES";
+const ROCKSDB_BULK_LOAD_OPTIMIZED: &str = "ROCKSDB_BULK_LOAD_OPTIMIZED";
+const SLED_COMPRESSION: &str = "SLED_COMPRESSION";
+
 fn main() -> Result<(), errors::Error> {
     let mut exec = LocalPool::new();
 
-    let port = match env::var("PORT") {
-        Ok(value) => value
-            .parse::<u16>()
-            .expect("Could not parse environment variable `PORT`"),
-        Err(_) => DEFAULT_PORT,
+    let matches = App::new("Indra DB")
+                        .version("1.2.0")
+                        .about("Indra DB server")
+                        .arg(Arg::with_name(PORT)
+                               .short("p")
+                               .long("port")
+                               .value_name("PORT")
+                               .help("The port to run the server on. Defaults to 27615")
+                               .takes_value(true)
+                               .default_value("27615"))
+                        .arg(Arg::with_name(DATABASE_URL)
+                               .short("d")
+                               .long("database")
+                               .value_name("DATABASE_URL")
+                               .help("The connection string to the underlying database. Defaults to memory://")
+                               .takes_value(true)
+                               .default_value("memory://"))
+                        .arg(Arg::with_name(ROCKSDB_MAX_OPEN_FILES)
+                            .long("max_open_files")
+                            .value_name("ROCKSDB_MAX_OPEN_FILES")
+                            .help("Sets the number of maximum open files to have open in RocksDB.")
+                            .takes_value(true)
+                            .default_value("512"))
+                        .arg(Arg::with_name(ROCKSDB_BULK_LOAD_OPTIMIZED)
+                            .long("bulk_load_opt")
+                            .value_name("ROCKSDB_BULK_LOAD_OPTIMIZED")
+                            .help("If set to true, RocksDB will be configured to optimize for bulk loading of data, likely at the detriment of any other kind of workload.")
+                            .takes_value(true)
+                            .default_value(""))
+                        .arg(Arg::with_name(SLED_COMPRESSION)
+                            .long("sled_compression")
+                            .value_name("SLED_COMPRESSION")
+                            .help("If set to true, compression will be enabled at the default zstd factor of 5. If set to an integer, compression will be enabled at the zstd specified factor.")
+                            .takes_value(true)
+                            .default_value(""))
+                          .get_matches();
+
+    let port = match matches.value_of(PORT) {
+        Some(value) => value.parse::<u16>().expect("Could not parse argument `port`"),
+        None => DEFAULT_PORT,
     };
 
     let addr = format!("127.0.0.1:{}", port)
@@ -28,18 +70,17 @@ fn main() -> Result<(), errors::Error> {
     let listener = exec.run_until(async { TcpListener::bind(&addr).await })?;
     println!("{}", listener.local_addr()?);
 
-    let connection_string = env::var("DATABASE_URL").unwrap_or_else(|_| "memory://".to_string());
-
+    let connection_string = matches.value_of(DATABASE_URL).unwrap();
     if connection_string.starts_with("rocksdb://") {
         let path = &connection_string[10..connection_string.len()];
 
-        let max_open_files_str = env::var("ROCKSDB_MAX_OPEN_FILES").unwrap_or_else(|_| "512".to_string());
+        let max_open_files_str = matches.value_of(ROCKSDB_MAX_OPEN_FILES).unwrap();
         let max_open_files = max_open_files_str.parse::<i32>().expect(
-            "Could not parse environment variable `ROCKSDB_MAX_OPEN_FILES`: must be an \
+            "Could not parse argument `max_open_files`: must be an \
              i32",
         );
 
-        let bulk_load_optimized = env::var("ROCKSDB_BULK_LOAD_OPTIMIZED").unwrap_or_else(|_| "".to_string()) == "true";
+        let bulk_load_optimized = matches.value_of(ROCKSDB_BULK_LOAD_OPTIMIZED).unwrap() == "true";
 
         let datastore = indradb::RocksdbDatastore::new(path, Some(max_open_files), bulk_load_optimized)
             .expect("Expected to be able to create the RocksDB datastore");
@@ -49,14 +90,14 @@ fn main() -> Result<(), errors::Error> {
     } else if connection_string.starts_with("sled://") {
         let path = &connection_string[7..connection_string.len()];
 
-        let sled_compression_str = env::var("SLEDDB_COMPRESSION").unwrap_or_else(|_| "".to_string());
+        let sled_compression_str = matches.value_of(SLED_COMPRESSION).unwrap();
         let sled_config = match &sled_compression_str[..] {
             "true" => indradb::SledConfig::with_compression(None),
             "false" | "" => indradb::SledConfig::default(),
             _ => {
                 let sled_compression = sled_compression_str
                     .parse::<i32>()
-                    .expect("Could not parse environment variable `SLEDDB_COMPRESSION`: must be a bool or i32");
+                    .expect("Could not parse argument `sled_compression`: must be a bool or i32");
                 indradb::SledConfig::with_compression(Some(sled_compression))
             }
         };

--- a/bin/src/server/main.rs
+++ b/bin/src/server/main.rs
@@ -8,6 +8,7 @@ mod errors;
 use async_std::net::TcpListener;
 use futures::executor::LocalPool;
 use std::net::ToSocketAddrs;
+use cli::{CliDatastoreArgs};
 
 fn main() -> Result<(), errors::Error> {
     let mut exec = LocalPool::new();
@@ -21,40 +22,28 @@ fn main() -> Result<(), errors::Error> {
     let listener = exec.run_until(async { TcpListener::bind(&addr).await })?;
     println!("{}", listener.local_addr()?);
 
-    if args.database_url.starts_with("rocksdb://") {
-        let path = &args.database_url[10..args.database_url.len()];
-        let datastore =
-            indradb::RocksdbDatastore::new(path, Some(args.max_open_files.unwrap()), args.bulk_load_opt.unwrap())
+    
+    match args.datastore_args {
+        CliDatastoreArgs::Rocksdb { path, max_open_files, bulk_load_optimized } => {
+            let datastore =
+            indradb::RocksdbDatastore::new(&path, Some(max_open_files), bulk_load_optimized)
                 .expect("Expected to be able to create the RocksDB datastore");
 
-        exec.run_until(common::server::run(listener, datastore, exec.spawner()))?;
-        Ok(())
-    } else if args.database_url.starts_with("sled://") {
-        let path = &args.database_url[7..args.database_url.len()];
+            exec.run_until(common::server::run(listener, datastore, exec.spawner()))?;
+            Ok(())
+        },
+        CliDatastoreArgs::Sled { path, sled_config } => {
+            let datastore = sled_config
+                .open(&path)
+                .expect("Expected to be able to create the Sled datastore");
 
-        let sled_compression = args.sled_compression.unwrap();
-        let sled_config = match &sled_compression[..] {
-            "true" => indradb::SledConfig::with_compression(None),
-            "false" | "" => indradb::SledConfig::default(),
-            _ => {
-                let sled_compression = sled_compression
-                    .parse::<i32>()
-                    .expect("Could not parse argument `sled_compression`: must be a bool or i32");
-                indradb::SledConfig::with_compression(Some(sled_compression))
-            }
-        };
-
-        let datastore = sled_config
-            .open(path)
-            .expect("Expected to be able to create the Sled datastore");
-
-        exec.run_until(common::server::run(listener, datastore, exec.spawner()))?;
-        Ok(())
-    } else if args.database_url == "memory://" {
-        let datastore = indradb::MemoryDatastore::default();
-        exec.run_until(common::server::run(listener, datastore, exec.spawner()))?;
-        Ok(())
-    } else {
-        Err(errors::Error::CouldNotParseDatabaseURL)
+            exec.run_until(common::server::run(listener, datastore, exec.spawner()))?;
+            Ok(())
+        },
+        CliDatastoreArgs::Memory => {
+            let datastore = indradb::MemoryDatastore::default();
+            exec.run_until(common::server::run(listener, datastore, exec.spawner()))?;
+            Ok(())
+        }
     }
 }

--- a/bin/src/server/main.rs
+++ b/bin/src/server/main.rs
@@ -2,66 +2,17 @@
 extern crate failure;
 extern crate clap;
 
+mod cli;
 mod errors;
 
-use std::net::ToSocketAddrs;
-
 use async_std::net::TcpListener;
-use clap::{App, Arg};
 use futures::executor::LocalPool;
-
-const DEFAULT_PORT: u16 = 27615;
-
-const PORT: &str = "PORT";
-const DATABASE_URL: &str = "DATABASE_URL";
-const ROCKSDB_MAX_OPEN_FILES: &str = "ROCKSDB_MAX_OPEN_FILES";
-const ROCKSDB_BULK_LOAD_OPTIMIZED: &str = "ROCKSDB_BULK_LOAD_OPTIMIZED";
-const SLED_COMPRESSION: &str = "SLED_COMPRESSION";
+use std::net::ToSocketAddrs;
 
 fn main() -> Result<(), errors::Error> {
     let mut exec = LocalPool::new();
-
-    let matches = App::new("Indra DB")
-                        .version("1.2.0")
-                        .about("Indra DB server")
-                        .arg(Arg::with_name(PORT)
-                               .short("p")
-                               .long("port")
-                               .value_name("PORT")
-                               .help("The port to run the server on. Defaults to 27615")
-                               .takes_value(true)
-                               .default_value("27615"))
-                        .arg(Arg::with_name(DATABASE_URL)
-                               .short("d")
-                               .long("database")
-                               .value_name("DATABASE_URL")
-                               .help("The connection string to the underlying database. Defaults to memory://")
-                               .takes_value(true)
-                               .default_value("memory://"))
-                        .arg(Arg::with_name(ROCKSDB_MAX_OPEN_FILES)
-                            .long("max_open_files")
-                            .value_name("ROCKSDB_MAX_OPEN_FILES")
-                            .help("Sets the number of maximum open files to have open in RocksDB.")
-                            .takes_value(true)
-                            .default_value("512"))
-                        .arg(Arg::with_name(ROCKSDB_BULK_LOAD_OPTIMIZED)
-                            .long("bulk_load_opt")
-                            .value_name("ROCKSDB_BULK_LOAD_OPTIMIZED")
-                            .help("If set to true, RocksDB will be configured to optimize for bulk loading of data, likely at the detriment of any other kind of workload.")
-                            .takes_value(true)
-                            .default_value(""))
-                        .arg(Arg::with_name(SLED_COMPRESSION)
-                            .long("sled_compression")
-                            .value_name("SLED_COMPRESSION")
-                            .help("If set to true, compression will be enabled at the default zstd factor of 5. If set to an integer, compression will be enabled at the zstd specified factor.")
-                            .takes_value(true)
-                            .default_value(""))
-                          .get_matches();
-
-    let port = match matches.value_of(PORT) {
-        Some(value) => value.parse::<u16>().expect("Could not parse argument `port`"),
-        None => DEFAULT_PORT,
-    };
+    let args = cli::parse_cli_args();
+    let port = args.port;
 
     let addr = format!("127.0.0.1:{}", port)
         .to_socket_addrs()?
@@ -70,32 +21,23 @@ fn main() -> Result<(), errors::Error> {
     let listener = exec.run_until(async { TcpListener::bind(&addr).await })?;
     println!("{}", listener.local_addr()?);
 
-    let connection_string = matches.value_of(DATABASE_URL).unwrap();
-    if connection_string.starts_with("rocksdb://") {
-        let path = &connection_string[10..connection_string.len()];
-
-        let max_open_files_str = matches.value_of(ROCKSDB_MAX_OPEN_FILES).unwrap();
-        let max_open_files = max_open_files_str.parse::<i32>().expect(
-            "Could not parse argument `max_open_files`: must be an \
-             i32",
-        );
-
-        let bulk_load_optimized = matches.value_of(ROCKSDB_BULK_LOAD_OPTIMIZED).unwrap() == "true";
-
-        let datastore = indradb::RocksdbDatastore::new(path, Some(max_open_files), bulk_load_optimized)
-            .expect("Expected to be able to create the RocksDB datastore");
+    if args.database_url.starts_with("rocksdb://") {
+        let path = &args.database_url[10..args.database_url.len()];
+        let datastore =
+            indradb::RocksdbDatastore::new(path, Some(args.max_open_files.unwrap()), args.bulk_load_opt.unwrap())
+                .expect("Expected to be able to create the RocksDB datastore");
 
         exec.run_until(common::server::run(listener, datastore, exec.spawner()))?;
         Ok(())
-    } else if connection_string.starts_with("sled://") {
-        let path = &connection_string[7..connection_string.len()];
+    } else if args.database_url.starts_with("sled://") {
+        let path = &args.database_url[7..args.database_url.len()];
 
-        let sled_compression_str = matches.value_of(SLED_COMPRESSION).unwrap();
-        let sled_config = match &sled_compression_str[..] {
+        let sled_compression = args.sled_compression.unwrap();
+        let sled_config = match &sled_compression[..] {
             "true" => indradb::SledConfig::with_compression(None),
             "false" | "" => indradb::SledConfig::default(),
             _ => {
-                let sled_compression = sled_compression_str
+                let sled_compression = sled_compression
                     .parse::<i32>()
                     .expect("Could not parse argument `sled_compression`: must be a bool or i32");
                 indradb::SledConfig::with_compression(Some(sled_compression))
@@ -108,7 +50,7 @@ fn main() -> Result<(), errors::Error> {
 
         exec.run_until(common::server::run(listener, datastore, exec.spawner()))?;
         Ok(())
-    } else if connection_string == "memory://" {
+    } else if args.database_url == "memory://" {
         let datastore = indradb::MemoryDatastore::default();
         exec.run_until(common::server::run(listener, datastore, exec.spawner()))?;
         Ok(())


### PR DESCRIPTION
Implements #101 
Changes 
- Use [clap](https://docs.rs/clap/2.33.3/clap/) command line parsing library to parse CLI args instead of env variables
- Edit README to reflect migration from env vars to CLI args