### PR TITLE
Extern-mination complete

### DIFF
--- a/lib/src/bytes.rs
+++ b/lib/src/bytes.rs
@@ -3,6 +3,7 @@ use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use chrono::offset::Utc;
 use chrono::{DateTime, NaiveDateTime};
 use chrono::{Duration, Timelike};
+use lazy_static::lazy_static;
 use std::i32;
 use std::i64;
 use std::io::Read;

--- a/lib/src/errors.rs
+++ b/lib/src/errors.rs
@@ -1,3 +1,4 @@
+use failure::Fail;
 #[cfg(feature = "rocksdb-datastore")]
 use rocksdb::Error as RocksDbError;
 use serde_json::Error as JsonError;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -11,24 +11,10 @@
 #[cfg(feature = "bench-suite")]
 extern crate test;
 
-extern crate chrono;
-extern crate core;
 #[macro_use]
 extern crate failure;
 #[macro_use]
 extern crate lazy_static;
-extern crate rand;
-extern crate regex;
-extern crate serde_json;
-extern crate uuid;
-
-#[cfg(feature = "rocksdb-datastore")]
-extern crate byteorder;
-#[cfg(feature = "rocksdb-datastore")]
-extern crate rocksdb;
-
-#[cfg(feature = "sled-datastore")]
-extern crate sled;
 
 #[cfg(feature = "test-suite")]
 #[macro_use]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -11,9 +11,6 @@
 #[cfg(feature = "bench-suite")]
 extern crate test;
 
-#[macro_use]
-extern crate lazy_static;
-
 #[cfg(feature = "test-suite")]
 #[macro_use]
 pub mod tests;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -12,8 +12,6 @@
 extern crate test;
 
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate lazy_static;
 
 #[cfg(feature = "test-suite")]

--- a/lib/src/models/types.rs
+++ b/lib/src/models/types.rs
@@ -1,5 +1,6 @@
 use crate::errors::{ValidationError, ValidationResult};
 use core::str::FromStr;
+use lazy_static::lazy_static;
 use regex::Regex;
 
 lazy_static! {

--- a/lib/src/util.rs
+++ b/lib/src/util.rs
@@ -2,6 +2,7 @@
 
 use crate::errors::{ValidationError, ValidationResult};
 use chrono::offset::Utc;
+use lazy_static::lazy_static;
 use uuid::v1::{Context, Timestamp};
 use uuid::Uuid;
 


### PR DESCRIPTION
Closes #160

Hello!

Broke it up into 3 commits because first time contributing to your repo.
1. Removed generic extern crate references in lib.rs
2. Replaced extern crate with macro use for failure crate with corresponding 'use' declaration for Error enum.
3. Replaced extern crate with macro use for lazy_static crate with corresponding 'use' declaration in bytes, types, and utils.

Tests passed

Note: I left the declaration for extern crate tests per my understanding of the [sysroot crate exception](https://doc.rust-lang.org/nightly/edition-guide/rust-2018/module-system/path-clarity.html#an-exception).

Happy to squash and any other changes you'd like.