### PR TITLE
Add repair flag

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -94,7 +94,7 @@ pub fn parse_cli_args() -> CliArgs {
             CliDatastoreArgs::Rocksdb {
                 path: matches.value_of_os(DATABASE_PATH).unwrap().to_os_string(),
                 max_open_files: value_t!(matches, ROCKSDB_MAX_OPEN_FILES, i32).unwrap_or_else(|e| e.exit()),
-                repair: matches.is_present("ROCKSDB_REPAIR")
+                repair: matches.is_present(ROCKSDB_REPAIR)
             }
         } else if let Some(matches) = matches.subcommand_matches("sled") {
             let sled_compression = matches.value_of(SLED_COMPRESSION).unwrap();

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -9,13 +9,14 @@ pub struct CliArgs {
 
 pub enum CliDatastoreArgs {
     Memory { path: Option<OsString> },
-    Rocksdb { path: OsString, max_open_files: i32 },
+    Rocksdb { path: OsString, max_open_files: i32, repair: bool },
     Sled { path: OsString, sled_config: SledConfig },
 }
 
 const ADDRESS: &str = "ADDRESS";
 const DATABASE_PATH: &str = "DATABASE_PATH";
 const ROCKSDB_MAX_OPEN_FILES: &str = "ROCKSDB_MAX_OPEN_FILES";
+const ROCKSDB_REPAIR: &str = "ROCKSDB_REPAIR";
 const SLED_COMPRESSION: &str = "SLED_COMPRESSION";
 const MEMORY_PERSIST_PATH: &str = "MEMORY_PERSIST_PATH";
 
@@ -53,6 +54,13 @@ pub fn parse_cli_args() -> CliArgs {
                 .help("Sets the number of maximum open files to have open in RocksDB.")
                 .takes_value(true)
                 .default_value("512"),
+        )
+        .arg(
+            Arg::with_name(ROCKSDB_REPAIR)
+                .long("repair")
+                .short("r")
+                .help("Repair the database at the given path rather than staring a server")
+                .takes_value(false)
         );
 
     let sled_subcommand = SubCommand::with_name("sled")
@@ -86,6 +94,7 @@ pub fn parse_cli_args() -> CliArgs {
             CliDatastoreArgs::Rocksdb {
                 path: matches.value_of_os(DATABASE_PATH).unwrap().to_os_string(),
                 max_open_files: value_t!(matches, ROCKSDB_MAX_OPEN_FILES, i32).unwrap_or_else(|e| e.exit()),
+                repair: matches.is_present("ROCKSDB_REPAIR")
             }
         } else if let Some(matches) = matches.subcommand_matches("sled") {
             let sled_compression = matches.value_of(SLED_COMPRESSION).unwrap();

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -8,9 +8,18 @@ pub struct CliArgs {
 }
 
 pub enum CliDatastoreArgs {
-    Memory { path: Option<OsString> },
-    Rocksdb { path: OsString, max_open_files: i32, repair: bool },
-    Sled { path: OsString, sled_config: SledConfig },
+    Memory {
+        path: Option<OsString>,
+    },
+    Rocksdb {
+        path: OsString,
+        max_open_files: i32,
+        repair: bool,
+    },
+    Sled {
+        path: OsString,
+        sled_config: SledConfig,
+    },
 }
 
 const ADDRESS: &str = "ADDRESS";
@@ -60,7 +69,7 @@ pub fn parse_cli_args() -> CliArgs {
                 .long("repair")
                 .short("r")
                 .help("Repair the database at the given path rather than staring a server")
-                .takes_value(false)
+                .takes_value(false),
         );
 
     let sled_subcommand = SubCommand::with_name("sled")
@@ -94,7 +103,7 @@ pub fn parse_cli_args() -> CliArgs {
             CliDatastoreArgs::Rocksdb {
                 path: matches.value_of_os(DATABASE_PATH).unwrap().to_os_string(),
                 max_open_files: value_t!(matches, ROCKSDB_MAX_OPEN_FILES, i32).unwrap_or_else(|e| e.exit()),
-                repair: matches.is_present(ROCKSDB_REPAIR)
+                repair: matches.is_present(ROCKSDB_REPAIR),
             }
         } else if let Some(matches) = matches.subcommand_matches("sled") {
             let sled_compression = matches.value_of(SLED_COMPRESSION).unwrap();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -19,13 +19,19 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     let addr = args.addr.to_socket_addrs()?.next().unwrap();
     let listener = TcpListener::bind(addr).await?;
     let binding = listener.local_addr()?;
-    println!("grpc://{}", binding);
 
     match args.datastore_args {
-        CliDatastoreArgs::Rocksdb { path, max_open_files } => {
+        CliDatastoreArgs::Rocksdb { path, max_open_files, repair } => {
+            if repair {
+                indradb::RocksdbDatastore::repair(&path, Some(max_open_files))
+                    .expect("Expected to be able to repair the RocksDB datastore");
+                println!("repair the datastore successfully");
+                return Ok(());
+            }
+
             let datastore = indradb::RocksdbDatastore::new(&path, Some(max_open_files))
                 .expect("Expected to be able to create the RocksDB datastore");
-
+            println!("grpc://{}", binding);
             proto::run_server(Arc::new(datastore), listener).await?;
             Ok(())
         }
@@ -33,12 +39,13 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             let datastore = sled_config
                 .open(&path)
                 .expect("Expected to be able to create the Sled datastore");
-
+            println!("grpc://{}", binding);
             proto::run_server(Arc::new(datastore), listener).await?;
             Ok(())
         }
         CliDatastoreArgs::Memory { path: None } => {
             let datastore = indradb::MemoryDatastore::default();
+            println!("grpc://{}", binding);
             proto::run_server(Arc::new(datastore), listener).await?;
             Ok(())
         }
@@ -48,7 +55,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             } else {
                 Arc::new(indradb::MemoryDatastore::create(path)?)
             };
-
+            println!("grpc://{}", binding);  
             proto::run_server(datastore.clone(), listener).await?;
             Ok(())
         }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -25,7 +25,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             if repair {
                 indradb::RocksdbDatastore::repair(&path, Some(max_open_files))
                     .expect("Expected to be able to repair the RocksDB datastore");
-                println!("repair the datastore successfully");
+                println!("repair successful");
                 return Ok(());
             }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -21,7 +21,11 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     let binding = listener.local_addr()?;
 
     match args.datastore_args {
-        CliDatastoreArgs::Rocksdb { path, max_open_files, repair } => {
+        CliDatastoreArgs::Rocksdb {
+            path,
+            max_open_files,
+            repair,
+        } => {
             if repair {
                 indradb::RocksdbDatastore::repair(&path, Some(max_open_files))
                     .expect("Expected to be able to repair the RocksDB datastore");
@@ -55,7 +59,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             } else {
                 Arc::new(indradb::MemoryDatastore::create(path)?)
             };
-            println!("grpc://{}", binding);  
+            println!("grpc://{}", binding);
             proto::run_server(datastore.clone(), listener).await?;
             Ok(())
         }


### PR DESCRIPTION
Implement #171 

=Modification=
- Add repair flag to the RocksDB argument
- Repair when the falg exists
- Move `println!("grpc://{}", binding)` to the proper location because repair process doesn't use a server

It is inefficient to repeat println code when altering the content of it in the future.
If there is another way, please let me know.