### PR TITLE
Make transactions more functional and object-safe

### DIFF
--- a/lib/fuzz/fuzz_targets/compare.rs
+++ b/lib/fuzz/fuzz_targets/compare.rs
@@ -629,8 +629,8 @@ fuzz_target!(|ops: Vec<Op>| {
         match op {
             Op::BulkInsert(items) => {
                 let items: Vec<indradb::BulkInsertItem> = items.into_iter().map(|i| i.into()).collect();
-                let v1 = d1.bulk_insert(items.clone().into_iter());
-                let v2 = d2.bulk_insert(items.into_iter());
+                let v1 = d1.bulk_insert(items.clone());
+                let v2 = d2.bulk_insert(items);
                 cmp!(v1, v2);
             }
             Op::CreateVertex(vertex) => {
@@ -733,8 +733,8 @@ fuzz_target!(|ops: Vec<Op>| {
                 cmp!(v1, v2);
             },
             Op::IndexProperty(t) => {
-                let v1 = d1.index_property(t.clone());
-                let v2 = d2.index_property(t);
+                let v1 = d1.index_property(t.clone().into());
+                let v2 = d2.index_property(t.into());
                 cmp!(v1, v2);
             }
         }

--- a/lib/src/benches/benches.rs
+++ b/lib/src/benches/benches.rs
@@ -27,7 +27,7 @@ pub fn bench_get_vertices<D: Datastore>(b: &mut Bencher, datastore: &mut D) {
     b.iter(|| {
         let trans = datastore.transaction().unwrap();
         let q = SpecificVertexQuery::single(id);
-        trans.get_vertices(q).unwrap();
+        trans.get_vertices(q.into()).unwrap();
     });
 }
 
@@ -67,7 +67,7 @@ pub fn bench_get_edges<D: Datastore>(b: &mut Bencher, datastore: &mut D) {
     b.iter(|| {
         let trans = datastore.transaction().unwrap();
         let q = SpecificEdgeQuery::single(key.clone());
-        trans.get_edges(q).unwrap();
+        trans.get_edges(q.into()).unwrap();
     });
 }
 
@@ -130,6 +130,6 @@ pub fn bench_bulk_insert<D: Datastore>(b: &mut Bencher, datastore: &mut D) {
     }
 
     b.iter(|| {
-        datastore.bulk_insert(items.clone().into_iter()).unwrap();
+        datastore.bulk_insert(items.clone()).unwrap();
     });
 }

--- a/lib/src/memory/datastore.rs
+++ b/lib/src/memory/datastore.rs
@@ -447,39 +447,6 @@ impl Datastore for MemoryDatastore {
             datastore: Arc::clone(&self.datastore),
         })
     }
-
-    fn index_property<T: Into<Identifier>>(&self, name: T) -> Result<()> {
-        let name = name.into();
-        let mut datastore = self.datastore.write().unwrap();
-
-        let mut property_container: HashMap<Json, HashSet<IndexedPropertyMember>> = HashMap::new();
-        for id in datastore.vertices.keys() {
-            if let Some(value) = datastore.vertex_properties.get(&(*id, name.clone())) {
-                property_container
-                    .entry(value.clone())
-                    .or_insert_with(HashSet::new)
-                    .insert(IndexedPropertyMember::Vertex(*id));
-            }
-        }
-        for key in datastore.edges.keys() {
-            if let Some(value) = datastore.edge_properties.get(&(key.clone(), name.clone())) {
-                property_container
-                    .entry(value.clone())
-                    .or_insert_with(HashSet::new)
-                    .insert(IndexedPropertyMember::Edge(key.clone()));
-            }
-        }
-
-        let existing_property_container = datastore.property_values.entry(name).or_insert_with(HashMap::new);
-        for (value, members) in property_container.into_iter() {
-            let existing_members = existing_property_container.entry(value).or_insert_with(HashSet::new);
-            for member in members {
-                existing_members.insert(member);
-            }
-        }
-
-        Ok(())
-    }
 }
 
 /// A transaction for manipulating in-memory datastores.
@@ -501,19 +468,16 @@ impl Transaction for MemoryTransaction {
         Ok(inserted)
     }
 
-    fn get_vertices<Q: Into<VertexQuery>>(&self, q: Q) -> Result<Vec<Vertex>> {
+    fn get_vertices(&self, q: VertexQuery) -> Result<Vec<Vertex>> {
         let datastore = self.datastore.read().unwrap();
-        let iter = datastore.get_vertex_values_by_query(q.into())?;
+        let iter = datastore.get_vertex_values_by_query(q)?;
         let iter = iter.map(|(uuid, t)| Vertex::with_id(uuid, t));
         Ok(iter.collect())
     }
 
-    fn delete_vertices<Q: Into<VertexQuery>>(&self, q: Q) -> Result<()> {
+    fn delete_vertices(&self, q: VertexQuery) -> Result<()> {
         let mut datastore = self.datastore.write().unwrap();
-        let deletable_vertices = datastore
-            .get_vertex_values_by_query(q.into())?
-            .map(|(k, _)| k)
-            .collect();
+        let deletable_vertices = datastore.get_vertex_values_by_query(q)?.map(|(k, _)| k).collect();
         datastore.delete_vertices(deletable_vertices);
         Ok(())
     }
@@ -535,10 +499,10 @@ impl Transaction for MemoryTransaction {
         Ok(true)
     }
 
-    fn get_edges<Q: Into<EdgeQuery>>(&self, q: Q) -> Result<Vec<Edge>> {
+    fn get_edges(&self, q: EdgeQuery) -> Result<Vec<Edge>> {
         let edge_values: Vec<(EdgeKey, DateTime<Utc>)> = {
             let datastore = self.datastore.read().unwrap();
-            let iter = datastore.get_edge_values_by_query(q.into())?;
+            let iter = datastore.get_edge_values_by_query(q)?;
             iter.collect()
         };
 
@@ -548,9 +512,9 @@ impl Transaction for MemoryTransaction {
         Ok(iter.collect())
     }
 
-    fn delete_edges<Q: Into<EdgeQuery>>(&self, q: Q) -> Result<()> {
+    fn delete_edges(&self, q: EdgeQuery) -> Result<()> {
         let mut datastore = self.datastore.write().unwrap();
-        let deletable_edges: Vec<EdgeKey> = datastore.get_edge_values_by_query(q.into())?.map(|(k, _)| k).collect();
+        let deletable_edges: Vec<EdgeKey> = datastore.get_edge_values_by_query(q)?.map(|(k, _)| k).collect();
         datastore.delete_edges(deletable_edges);
         Ok(())
     }
@@ -596,9 +560,9 @@ impl Transaction for MemoryTransaction {
         Ok(result)
     }
 
-    fn get_all_vertex_properties<Q: Into<VertexQuery>>(&self, q: Q) -> Result<Vec<VertexProperties>> {
+    fn get_all_vertex_properties(&self, q: VertexQuery) -> Result<Vec<VertexProperties>> {
         let datastore = self.datastore.read().unwrap();
-        let vertex_values = datastore.get_vertex_values_by_query(q.into())?;
+        let vertex_values = datastore.get_vertex_values_by_query(q)?;
 
         let mut result = Vec::new();
         for (id, t) in vertex_values {
@@ -671,9 +635,9 @@ impl Transaction for MemoryTransaction {
         Ok(result)
     }
 
-    fn get_all_edge_properties<Q: Into<EdgeQuery>>(&self, q: Q) -> Result<Vec<EdgeProperties>> {
+    fn get_all_edge_properties(&self, q: EdgeQuery) -> Result<Vec<EdgeProperties>> {
         let datastore = self.datastore.read().unwrap();
-        let edge_values = datastore.get_edge_values_by_query(q.into())?;
+        let edge_values = datastore.get_edge_values_by_query(q)?;
 
         let mut result = Vec::new();
         for (id, t) in edge_values {
@@ -729,6 +693,38 @@ impl Transaction for MemoryTransaction {
             deletable_edge_properties.push((key, q.name.clone()));
         }
         datastore.delete_edge_properties(deletable_edge_properties);
+        Ok(())
+    }
+
+    fn index_property(&self, name: Identifier) -> Result<()> {
+        let mut datastore = self.datastore.write().unwrap();
+
+        let mut property_container: HashMap<Json, HashSet<IndexedPropertyMember>> = HashMap::new();
+        for id in datastore.vertices.keys() {
+            if let Some(value) = datastore.vertex_properties.get(&(*id, name.clone())) {
+                property_container
+                    .entry(value.clone())
+                    .or_insert_with(HashSet::new)
+                    .insert(IndexedPropertyMember::Vertex(*id));
+            }
+        }
+        for key in datastore.edges.keys() {
+            if let Some(value) = datastore.edge_properties.get(&(key.clone(), name.clone())) {
+                property_container
+                    .entry(value.clone())
+                    .or_insert_with(HashSet::new)
+                    .insert(IndexedPropertyMember::Edge(key.clone()));
+            }
+        }
+
+        let existing_property_container = datastore.property_values.entry(name).or_insert_with(HashMap::new);
+        for (value, members) in property_container.into_iter() {
+            let existing_members = existing_property_container.entry(value).or_insert_with(HashSet::new);
+            for member in members {
+                existing_members.insert(member);
+            }
+        }
+
         Ok(())
     }
 }

--- a/lib/src/memory/mod.rs
+++ b/lib/src/memory/mod.rs
@@ -33,7 +33,7 @@ fn should_serialize() {
     let datastore = MemoryDatastore::read(path.path()).unwrap();
     let trans = datastore.transaction().unwrap();
     assert_eq!(trans.get_vertex_count().unwrap(), 1);
-    let vertices = trans.get_vertices(SpecificVertexQuery::new(vec![id])).unwrap();
+    let vertices = trans.get_vertices(SpecificVertexQuery::new(vec![id]).into()).unwrap();
     assert_eq!(vertices.len(), 1);
     assert_eq!(vertices[0].id, id);
     assert_eq!(vertices[0].t, Identifier::default());

--- a/lib/src/tests/bulk_insert.rs
+++ b/lib/src/tests/bulk_insert.rs
@@ -16,7 +16,7 @@ pub fn should_bulk_insert<D: Datastore>(datastore: &mut D) {
         BulkInsertItem::Vertex(inbound_v.clone()),
     ];
 
-    datastore.bulk_insert(items.into_iter()).unwrap();
+    datastore.bulk_insert(items).unwrap();
 
     // Record the start and end time. Round off the the nanoseconds off the
     // start time, since some implementations may not have that level of
@@ -39,13 +39,13 @@ pub fn should_bulk_insert<D: Datastore>(datastore: &mut D) {
         ),
     ];
 
-    datastore.bulk_insert(items.into_iter()).unwrap();
+    datastore.bulk_insert(items).unwrap();
 
     let end_time = Utc::now();
 
     let trans = datastore.transaction().unwrap();
     let vertices = trans
-        .get_vertices(SpecificVertexQuery::new(vec![outbound_v.id, inbound_v.id]))
+        .get_vertices(SpecificVertexQuery::new(vec![outbound_v.id, inbound_v.id]).into())
         .unwrap();
 
     assert_eq!(vertices.len(), 2);
@@ -54,7 +54,7 @@ pub fn should_bulk_insert<D: Datastore>(datastore: &mut D) {
     assert_eq!(vertices[1].id, inbound_v.id);
     assert_eq!(vertices[1].t, inbound_v.t);
 
-    let edges = trans.get_edges(SpecificEdgeQuery::single(key.clone())).unwrap();
+    let edges = trans.get_edges(SpecificEdgeQuery::single(key.clone()).into()).unwrap();
 
     assert_eq!(edges.len(), 1);
     assert_eq!(edges[0].key.outbound_id, outbound_v.id);
@@ -99,7 +99,7 @@ pub fn should_bulk_insert_a_redundant_vertex<D: Datastore>(datastore: &mut D) {
     assert!(trans.create_vertex(&vertex).unwrap());
 
     let items = vec![BulkInsertItem::Vertex(vertex)];
-    assert!(datastore.bulk_insert(items.into_iter()).is_ok());
+    assert!(datastore.bulk_insert(items).is_ok());
 }
 
 // As an optimization, bulk insert does not verify that the vertices
@@ -115,7 +115,7 @@ pub fn should_bulk_insert_an_invalid_edge<D: Datastore>(datastore: &mut D) {
     let edge_t = Identifier::new("test_edge_type").unwrap();
 
     let items = vec![BulkInsertItem::Edge(EdgeKey::new(v1.id, edge_t.clone(), v2.id))];
-    assert!(datastore.bulk_insert(items.into_iter()).is_ok());
+    assert!(datastore.bulk_insert(items).is_ok());
     let items = vec![BulkInsertItem::Edge(EdgeKey::new(v2.id, edge_t, v1.id))];
-    assert!(datastore.bulk_insert(items.into_iter()).is_ok());
+    assert!(datastore.bulk_insert(items).is_ok());
 }

--- a/lib/src/tests/indexing.rs
+++ b/lib/src/tests/indexing.rs
@@ -36,9 +36,8 @@ fn setup_edge_with_indexed_property<D: Datastore>(
 
 pub fn should_not_query_unindexed_vertex_property<D: Datastore>(datastore: &mut D) {
     let trans = datastore.transaction().unwrap();
-    let result = trans.get_vertices(models::PropertyPresenceVertexQuery::new(
-        models::Identifier::new("foo").unwrap(),
-    ));
+    let result =
+        trans.get_vertices(models::PropertyPresenceVertexQuery::new(models::Identifier::new("foo").unwrap()).into());
     match result {
         Err(Error::NotIndexed) => (),
         _ => assert!(false, "unexpected result: {:?}", result),
@@ -47,9 +46,8 @@ pub fn should_not_query_unindexed_vertex_property<D: Datastore>(datastore: &mut 
 
 pub fn should_not_query_unindexed_edge_property<D: Datastore>(datastore: &mut D) {
     let trans = datastore.transaction().unwrap();
-    let result = trans.get_edges(models::PropertyPresenceEdgeQuery::new(
-        models::Identifier::new("foo").unwrap(),
-    ));
+    let result =
+        trans.get_edges(models::PropertyPresenceEdgeQuery::new(models::Identifier::new("foo").unwrap()).into());
     match result {
         Err(Error::NotIndexed) => (),
         _ => assert!(false, "unexpected result: {:?}", result),
@@ -72,13 +70,15 @@ pub fn should_index_existing_vertex_property<D: Datastore>(datastore: &mut D) {
 
     // Get the vertex
     let result = trans
-        .get_vertices(models::PropertyPresenceVertexQuery::new(property_name.clone()))
+        .get_vertices(models::PropertyPresenceVertexQuery::new(property_name.clone()).into())
         .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].id, v.id);
 
     // Get the vertex with a piped query
-    let result = trans.get_vertices(q.with_property(property_name.clone())).unwrap();
+    let result = trans
+        .get_vertices(q.with_property(property_name.clone()).into())
+        .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].id, v.id);
 }
@@ -105,13 +105,13 @@ pub fn should_index_existing_edge_property<D: Datastore>(datastore: &mut D) {
 
     // Get the edge
     let result = trans
-        .get_edges(models::PropertyPresenceEdgeQuery::new(property_name.clone()))
+        .get_edges(models::PropertyPresenceEdgeQuery::new(property_name.clone()).into())
         .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].key, key);
 
     // Get the edge with a piped query
-    let result = trans.get_edges(q.with_property(property_name.clone())).unwrap();
+    let result = trans.get_edges(q.with_property(property_name.clone()).into()).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].key, key);
 }
@@ -121,9 +121,9 @@ pub fn should_delete_indexed_vertex_property<D: Datastore>(datastore: &mut D) {
     let id = setup_vertex_with_indexed_property(datastore, &property_name);
     let trans = datastore.transaction().unwrap();
     let q = models::SpecificVertexQuery::single(id);
-    trans.delete_vertices(q.clone()).unwrap();
+    trans.delete_vertices(q.clone().into()).unwrap();
     let result = trans
-        .get_vertices(models::PropertyPresenceVertexQuery::new(property_name))
+        .get_vertices(models::PropertyPresenceVertexQuery::new(property_name).into())
         .unwrap();
     assert_eq!(result.len(), 0);
 }
@@ -133,9 +133,9 @@ pub fn should_delete_indexed_edge_property<D: Datastore>(datastore: &mut D) {
     let key = setup_edge_with_indexed_property(datastore, &property_name);
     let trans = datastore.transaction().unwrap();
     let q = models::SpecificEdgeQuery::single(key);
-    trans.delete_edges(q.clone()).unwrap();
+    trans.delete_edges(q.clone().into()).unwrap();
     let result = trans
-        .get_edges(models::PropertyPresenceEdgeQuery::new(property_name))
+        .get_edges(models::PropertyPresenceEdgeQuery::new(property_name).into())
         .unwrap();
     assert_eq!(result.len(), 0);
 }
@@ -154,23 +154,22 @@ pub fn should_update_indexed_vertex_property<D: Datastore>(datastore: &mut D) {
 
     // property foo should not be the old value
     let result = trans
-        .get_vertices(models::PropertyValueVertexQuery::new(
-            property_name.clone(),
-            json_true.clone(),
-        ))
+        .get_vertices(models::PropertyValueVertexQuery::new(property_name.clone(), json_true.clone()).into())
         .unwrap();
     assert_eq!(result.len(), 0);
     let result = trans
         .get_vertices(
             q.clone()
-                .with_property_equal_to(property_name.clone(), json_true.clone()),
+                .with_property_equal_to(property_name.clone(), json_true.clone())
+                .into(),
         )
         .unwrap();
     assert_eq!(result.len(), 0);
     let result = trans
         .get_vertices(
             q.clone()
-                .with_property_not_equal_to(property_name.clone(), json_true.clone()),
+                .with_property_not_equal_to(property_name.clone(), json_true.clone())
+                .into(),
         )
         .unwrap();
     assert_eq!(result.len(), 1);
@@ -178,23 +177,24 @@ pub fn should_update_indexed_vertex_property<D: Datastore>(datastore: &mut D) {
 
     // property foo should be the new value
     let result = trans
-        .get_vertices(models::PropertyValueVertexQuery::new(
-            property_name.clone(),
-            json_false.clone(),
-        ))
+        .get_vertices(models::PropertyValueVertexQuery::new(property_name.clone(), json_false.clone()).into())
         .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].id, id);
     let result = trans
         .get_vertices(
             q.clone()
-                .with_property_equal_to(property_name.clone(), json_false.clone()),
+                .with_property_equal_to(property_name.clone(), json_false.clone())
+                .into(),
         )
         .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].id, id);
     let result = trans
-        .get_vertices(q.with_property_not_equal_to(property_name.clone(), json_false.clone()))
+        .get_vertices(
+            q.with_property_not_equal_to(property_name.clone(), json_false.clone())
+                .into(),
+        )
         .unwrap();
     assert_eq!(result.len(), 0);
 }
@@ -213,44 +213,44 @@ pub fn should_update_indexed_edge_property<D: Datastore>(datastore: &mut D) {
 
     // property foo should not be the old value
     let result = trans
-        .get_edges(models::PropertyValueEdgeQuery::new(
-            property_name.clone(),
-            json_true.clone(),
-        ))
+        .get_edges(models::PropertyValueEdgeQuery::new(property_name.clone(), json_true.clone()).into())
         .unwrap();
     assert_eq!(result.len(), 0);
     let result = trans
         .get_edges(
             q.clone()
-                .with_property_equal_to(property_name.clone(), json_true.clone()),
+                .with_property_equal_to(property_name.clone(), json_true.clone())
+                .into(),
         )
         .unwrap();
     assert_eq!(result.len(), 0);
     let result = trans
-        .get_edges(q.clone().with_property_not_equal_to(property_name.clone(), json_true))
+        .get_edges(
+            q.clone()
+                .with_property_not_equal_to(property_name.clone(), json_true)
+                .into(),
+        )
         .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].key, key.clone());
 
     // property foo should be the new value
     let result = trans
-        .get_edges(models::PropertyValueEdgeQuery::new(
-            property_name.clone(),
-            json_false.clone(),
-        ))
+        .get_edges(models::PropertyValueEdgeQuery::new(property_name.clone(), json_false.clone()).into())
         .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].key, key);
     let result = trans
         .get_edges(
             q.clone()
-                .with_property_equal_to(property_name.clone(), json_false.clone()),
+                .with_property_equal_to(property_name.clone(), json_false.clone())
+                .into(),
         )
         .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].key, key);
     let result = trans
-        .get_edges(q.with_property_not_equal_to(property_name.clone(), json_false))
+        .get_edges(q.with_property_not_equal_to(property_name.clone(), json_false).into())
         .unwrap();
     assert_eq!(result.len(), 0);
 }
@@ -260,7 +260,7 @@ pub fn should_query_indexed_vertex_property_empty<D: Datastore>(datastore: &mut 
     let trans = datastore.transaction().unwrap();
     datastore.index_property(property_name.clone()).unwrap();
     let result = trans
-        .get_vertices(models::PropertyPresenceVertexQuery::new(property_name))
+        .get_vertices(models::PropertyPresenceVertexQuery::new(property_name).into())
         .unwrap();
     assert_eq!(result.len(), 0);
 }
@@ -270,7 +270,7 @@ pub fn should_query_indexed_edge_property_empty<D: Datastore>(datastore: &mut D)
     let trans = datastore.transaction().unwrap();
     datastore.index_property(property_name.clone()).unwrap();
     let result = trans
-        .get_edges(models::PropertyPresenceEdgeQuery::new(property_name))
+        .get_edges(models::PropertyPresenceEdgeQuery::new(property_name).into())
         .unwrap();
     assert_eq!(result.len(), 0);
 }

--- a/lib/src/tests/properties.rs
+++ b/lib/src/tests/properties.rs
@@ -54,7 +54,7 @@ pub fn should_get_all_vertex_properties<D: Datastore>(datastore: &mut D) {
     let q3 = SpecificVertexQuery::single(v3.id);
 
     // Check to make sure there are no initial properties
-    let all_result = trans.get_all_vertex_properties(q2.clone()).unwrap();
+    let all_result = trans.get_all_vertex_properties(q2.clone().into()).unwrap();
     assert_eq!(all_result.len(), 1);
     assert_eq!(all_result[0].props.len(), 0);
 
@@ -72,11 +72,11 @@ pub fn should_get_all_vertex_properties<D: Datastore>(datastore: &mut D) {
         )
         .unwrap();
 
-    let result_1 = trans.get_all_vertex_properties(q1).unwrap();
+    let result_1 = trans.get_all_vertex_properties(q1.into()).unwrap();
     assert_eq!(result_1.len(), 1);
     assert_eq!(result_1[0].props.len(), 0);
 
-    let result_2 = trans.get_all_vertex_properties(q2).unwrap();
+    let result_2 = trans.get_all_vertex_properties(q2.into()).unwrap();
     assert_eq!(result_2.len(), 1);
     assert_eq!(result_2[0].props.len(), 2);
     assert_eq!(result_2[0].props[0].name, Identifier::new("a").unwrap());
@@ -84,7 +84,7 @@ pub fn should_get_all_vertex_properties<D: Datastore>(datastore: &mut D) {
     assert_eq!(result_2[0].props[1].name, Identifier::new("b").unwrap());
     assert_eq!(result_2[0].props[1].value, serde_json::Value::Bool(true));
 
-    let result_3 = trans.get_all_vertex_properties(q3).unwrap();
+    let result_3 = trans.get_all_vertex_properties(q3.into()).unwrap();
     assert_eq!(result_3.len(), 1);
     assert_eq!(result_3[0].props.len(), 0);
 }
@@ -167,7 +167,7 @@ pub fn should_get_all_edge_properties<D: Datastore>(datastore: &mut D) {
     trans.create_edge(&key).unwrap();
 
     // Check to make sure there's no initial value
-    let result = trans.get_all_edge_properties(eq.clone()).unwrap();
+    let result = trans.get_all_edge_properties(eq.clone().into()).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].props.len(), 0);
 
@@ -179,7 +179,7 @@ pub fn should_get_all_edge_properties<D: Datastore>(datastore: &mut D) {
         .set_edge_properties(q2.clone(), serde_json::Value::Bool(true))
         .unwrap();
 
-    let result = trans.get_all_edge_properties(eq.clone()).unwrap();
+    let result = trans.get_all_edge_properties(eq.clone().into()).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].props.len(), 2);
     assert_eq!(result[0].props[0].name, Identifier::new("edge-prop-1").unwrap());
@@ -191,7 +191,7 @@ pub fn should_get_all_edge_properties<D: Datastore>(datastore: &mut D) {
     trans.delete_edge_properties(q1).unwrap();
     trans.delete_edge_properties(q2).unwrap();
 
-    let result = trans.get_all_edge_properties(eq).unwrap();
+    let result = trans.get_all_edge_properties(eq.into()).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].props.len(), 0);
 }

--- a/proto/src/client.rs
+++ b/proto/src/client.rs
@@ -137,11 +137,7 @@ impl Client {
     ///
     /// # Arguments
     /// * `items`: The items to insert.
-    pub async fn bulk_insert<I>(&mut self, items: I) -> Result<(), ClientError>
-    where
-        I: Iterator<Item = indradb::BulkInsertItem>,
-    {
-        let items: Vec<indradb::BulkInsertItem> = items.collect();
+    pub async fn bulk_insert(&mut self, items: Vec<indradb::BulkInsertItem>) -> Result<(), ClientError> {
         let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
         tokio::spawn(async move {
             for item in items.into_iter() {
@@ -162,12 +158,11 @@ impl Client {
         Ok(Transaction::new(tx, response.into_inner()))
     }
 
-    pub async fn index_property<T: Into<indradb::Identifier>>(&mut self, name: T) -> Result<(), ClientError> {
-        self.0
-            .index_property(Request::new(crate::IndexPropertyRequest {
-                name: Some(name.into().into()),
-            }))
-            .await?;
+    pub async fn index_property(&mut self, name: indradb::Identifier) -> Result<(), ClientError> {
+        let request = Request::new(crate::IndexPropertyRequest {
+            name: Some(name.into()),
+        });
+        self.0.index_property(request).await?;
         Ok(())
     }
 }

--- a/proto/src/server.rs
+++ b/proto/src/server.rs
@@ -63,7 +63,7 @@ impl<D: indradb::Datastore<Trans = T> + Send + Sync + 'static, T: indradb::Trans
         };
 
         let datastore = self.datastore.clone();
-        map_indradb_result(datastore.bulk_insert(items.into_iter()))?;
+        map_indradb_result(datastore.bulk_insert(items))?;
         Ok(Response::new(()))
     }
 

--- a/proto/src/tests.rs
+++ b/proto/src/tests.rs
@@ -65,10 +65,12 @@ impl indradb::Datastore for ClientDatastore {
         map_client_result(self.exec.borrow_mut().block_on(self.client.borrow_mut().sync()))
     }
 
-    fn bulk_insert<I>(&self, items: I) -> Result<(), indradb::Error>
-    where
-        I: Iterator<Item = indradb::BulkInsertItem>,
-    {
+    fn transaction(&self) -> Result<ClientTransaction, indradb::Error> {
+        let trans = map_client_result(self.exec.borrow_mut().block_on(self.client.borrow_mut().transaction()))?;
+        Ok(ClientTransaction::new(trans, self.exec.clone()))
+    }
+
+    fn bulk_insert(&self, items: Vec<indradb::BulkInsertItem>) -> Result<(), indradb::Error> {
         map_client_result(
             self.exec
                 .borrow_mut()
@@ -76,12 +78,7 @@ impl indradb::Datastore for ClientDatastore {
         )
     }
 
-    fn transaction(&self) -> Result<ClientTransaction, indradb::Error> {
-        let trans = map_client_result(self.exec.borrow_mut().block_on(self.client.borrow_mut().transaction()))?;
-        Ok(ClientTransaction::new(trans, self.exec.clone()))
-    }
-
-    fn index_property<T: Into<indradb::Identifier>>(&self, name: T) -> Result<(), indradb::Error> {
+    fn index_property(&self, name: indradb::Identifier) -> Result<(), indradb::Error> {
         map_client_result(
             self.exec
                 .borrow_mut()
@@ -121,11 +118,11 @@ impl indradb::Transaction for ClientTransaction {
         )
     }
 
-    fn get_vertices<Q: Into<indradb::VertexQuery>>(&self, q: Q) -> Result<Vec<indradb::Vertex>, indradb::Error> {
+    fn get_vertices(&self, q: indradb::VertexQuery) -> Result<Vec<indradb::Vertex>, indradb::Error> {
         map_client_result(self.exec.borrow_mut().block_on(self.trans.borrow_mut().get_vertices(q)))
     }
 
-    fn delete_vertices<Q: Into<indradb::VertexQuery>>(&self, q: Q) -> Result<(), indradb::Error> {
+    fn delete_vertices(&self, q: indradb::VertexQuery) -> Result<(), indradb::Error> {
         map_client_result(
             self.exec
                 .borrow_mut()
@@ -145,11 +142,11 @@ impl indradb::Transaction for ClientTransaction {
         map_client_result(self.exec.borrow_mut().block_on(self.trans.borrow_mut().create_edge(e)))
     }
 
-    fn get_edges<Q: Into<indradb::EdgeQuery>>(&self, q: Q) -> Result<Vec<indradb::Edge>, indradb::Error> {
+    fn get_edges(&self, q: indradb::EdgeQuery) -> Result<Vec<indradb::Edge>, indradb::Error> {
         map_client_result(self.exec.borrow_mut().block_on(self.trans.borrow_mut().get_edges(q)))
     }
 
-    fn delete_edges<Q: Into<indradb::EdgeQuery>>(&self, q: Q) -> Result<(), indradb::Error> {
+    fn delete_edges(&self, q: indradb::EdgeQuery) -> Result<(), indradb::Error> {
         map_client_result(self.exec.borrow_mut().block_on(self.trans.borrow_mut().delete_edges(q)))
     }
 
@@ -177,9 +174,9 @@ impl indradb::Transaction for ClientTransaction {
         )
     }
 
-    fn get_all_vertex_properties<Q: Into<indradb::VertexQuery>>(
+    fn get_all_vertex_properties(
         &self,
-        q: Q,
+        q: indradb::VertexQuery,
     ) -> Result<Vec<indradb::VertexProperties>, indradb::Error> {
         map_client_result(
             self.exec
@@ -216,10 +213,7 @@ impl indradb::Transaction for ClientTransaction {
         )
     }
 
-    fn get_all_edge_properties<Q: Into<indradb::EdgeQuery>>(
-        &self,
-        q: Q,
-    ) -> Result<Vec<indradb::EdgeProperties>, indradb::Error> {
+    fn get_all_edge_properties(&self, q: indradb::EdgeQuery) -> Result<Vec<indradb::EdgeProperties>, indradb::Error> {
         map_client_result(
             self.exec
                 .borrow_mut()
@@ -245,6 +239,14 @@ impl indradb::Transaction for ClientTransaction {
                 .borrow_mut()
                 .block_on(self.trans.borrow_mut().delete_edge_properties(q)),
         )
+    }
+
+    fn bulk_insert(&self, _items: Vec<indradb::BulkInsertItem>) -> Result<(), indradb::Error> {
+        unimplemented!();
+    }
+
+    fn index_property(&self, _name: indradb::Identifier) -> Result<(), indradb::Error> {
+        unimplemented!();
     }
 }
 


### PR DESCRIPTION
Changes to the datastore and transaction traits:

* Moved property indexing and bulk insert to the transaction trait. The datastore trait still has these functions, but they're now defaulted to just calling the transaction functions.
* Made the transaction trait object-safe.
* Made the datastore "more" object-safe (though it's not because of the associated type.) This was done to keep the interface similar to transaction.

These changes were made in order to help support plugins (#210).