### PR TITLE
Refactor errors

### DIFF
--- a/lib/src/errors.rs
+++ b/lib/src/errors.rs
@@ -1,23 +1,16 @@
 use std::error::Error as StdError;
 use std::fmt;
-use std::io::Error as IoError;
 use std::result::Result as StdResult;
 
 use bincode::Error as BincodeError;
 #[cfg(feature = "rocksdb-datastore")]
 use rocksdb::Error as RocksDbError;
 use serde_json::Error as JsonError;
-use tempfile::PersistError as TempFilePersistError;
 
 /// An error triggered by the datastore
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum Error {
-    /// Json (de-)serialization failed
-    Json {
-        inner: JsonError,
-    },
-
     UuidTaken,
 
     /// An error occurred in the underlying datastore
@@ -35,7 +28,6 @@ pub enum Error {
 impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match *self {
-            Error::Json { ref inner } => Some(inner),
             Error::Datastore { ref inner } => Some(&**inner),
             _ => None,
         }
@@ -45,7 +37,6 @@ impl StdError for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Json { ref inner } => write!(f, "json error: {}", inner),
             Error::UuidTaken => write!(f, "UUID already taken"),
             Error::Datastore { ref inner } => write!(f, "error in the underlying datastore: {}", inner),
             Error::NotIndexed => write!(f, "query attempted on a property that isn't indexed"),
@@ -56,12 +47,6 @@ impl fmt::Display for Error {
 
 impl From<JsonError> for Error {
     fn from(err: JsonError) -> Self {
-        Error::Json { inner: err }
-    }
-}
-
-impl From<IoError> for Error {
-    fn from(err: IoError) -> Self {
         Error::Datastore { inner: Box::new(err) }
     }
 }
@@ -75,12 +60,6 @@ impl From<BincodeError> for Error {
 #[cfg(feature = "rocksdb-datastore")]
 impl From<RocksDbError> for Error {
     fn from(err: RocksDbError) -> Self {
-        Error::Datastore { inner: Box::new(err) }
-    }
-}
-
-impl From<TempFilePersistError> for Error {
-    fn from(err: TempFilePersistError) -> Self {
         Error::Datastore { inner: Box::new(err) }
     }
 }

--- a/lib/src/memory/datastore.rs
+++ b/lib/src/memory/datastore.rs
@@ -433,11 +433,13 @@ impl Datastore for MemoryDatastore {
 
     fn sync(&self) -> Result<()> {
         if let Some(ref persist_path) = self.path {
-            let temp_path = NamedTempFile::new()?;
+            let temp_path = NamedTempFile::new().map_err(|err| Error::Datastore { inner: Box::new(err) })?;
             let buf = BufWriter::new(temp_path.as_file());
             let datastore = self.datastore.read().unwrap();
             bincode::serialize_into(buf, &*datastore)?;
-            temp_path.persist(persist_path)?;
+            temp_path
+                .persist(persist_path)
+                .map_err(|err| Error::Datastore { inner: Box::new(err) })?;
         }
         Ok(())
     }

--- a/lib/src/memory/datastore.rs
+++ b/lib/src/memory/datastore.rs
@@ -433,13 +433,13 @@ impl Datastore for MemoryDatastore {
 
     fn sync(&self) -> Result<()> {
         if let Some(ref persist_path) = self.path {
-            let temp_path = NamedTempFile::new().map_err(|err| Error::Datastore { inner: Box::new(err) })?;
+            let temp_path = NamedTempFile::new().map_err(|err| Error::Datastore(Box::new(err)))?;
             let buf = BufWriter::new(temp_path.as_file());
             let datastore = self.datastore.read().unwrap();
             bincode::serialize_into(buf, &*datastore)?;
             temp_path
                 .persist(persist_path)
-                .map_err(|err| Error::Datastore { inner: Box::new(err) })?;
+                .map_err(|err| Error::Datastore(Box::new(err)))?;
         }
         Ok(())
     }


### PR DESCRIPTION
Since we'll be cutting 3.0, now is the opportunity to make some (small) tweaks to errors.

* Remove ambiguous error variant
* Use unnamed inner errors