### PR TITLE
Remove optimizations for bulk insert.

### DIFF
--- a/lib/src/rdb/datastore.rs
+++ b/lib/src/rdb/datastore.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use chrono::offset::Utc;
 use chrono::DateTime;
-use rocksdb::{DBCompactionStyle, Options, WriteBatch, WriteOptions, DB};
+use rocksdb::{DBCompactionStyle, Options, WriteBatch, DB};
 use uuid::Uuid;
 
 const CF_NAMES: [&str; 9] = [
@@ -746,13 +746,7 @@ impl Datastore for RocksdbDatastore {
             }
         }
 
-        // NOTE: syncing and WAL are disabled for bulk inserts to maximize
-        // performance
-        let mut opts = WriteOptions::default();
-        opts.set_sync(false);
-        opts.disable_wal(true);
-        self.db.write_opt(batch, &opts)?;
-
+        self.db.write(batch)?;
         Ok(())
     }
 


### PR DESCRIPTION
The underlying RocksDB library doesn't flush/sync on drop, so these optimizations risk losing data if the server is terminated (even graciously) after the bulk insert.