### PR TITLE
3.0.0

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,5 +21,13 @@ tonic = "0.5.2"
 tokio = { version = "1.11.0", features = ["macros", "rt-multi-thread"] }
 serde_json = "1.0.67"
 uuid = { version = "0.8.2", features = ["serde"] }
-indradb-lib = { path = "../lib", features = ["rocksdb-datastore"] }
-indradb-proto = { path = "../proto", features = ["client"] }
+
+[dependencies.indradb-lib]
+path = "../lib"
+version = "3.0.0"
+features = ["rocksdb-datastore"]
+
+[dependencies.indradb-proto]
+path = "../proto"
+version = "3.0.0"
+features = ["client"]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indradb-client"
-version = "2.2.0"
+version = "3.0.0"
 authors = ["Yusuf Simonson <simonson@gmail.com>"]
 description = "CLI client for IndraDB"
 homepage = "https://indradb.github.io"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indradb-lib"
-version = "2.2.0"
+version = "3.0.0"
 authors = ["Yusuf Simonson <simonson@gmail.com>"]
 description = "A graph database library"
 homepage = "https://indradb.github.io"

--- a/lib/fuzz/Cargo.lock
+++ b/lib/fuzz/Cargo.lock
@@ -154,7 +154,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "indradb-lib"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "bincode",
  "byteorder",

--- a/plugins/host/Cargo.toml
+++ b/plugins/host/Cargo.toml
@@ -1,8 +1,16 @@
 [package]
 name = "indradb-plugin-host"
 version = "0.1.0"
-edition = "2021"
 build = "build.rs"
+authors = ["Yusuf Simonson <simonson@gmail.com>"]
+description = "A graph database library"
+homepage = "https://indradb.github.io"
+repository = "https://github.com/indradb/indradb"
+keywords = ["graph", "database"]
+categories = ["database", "database-implementations"]
+license = "MPL-2.0"
+edition = "2021"
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/plugins/host/Cargo.toml
+++ b/plugins/host/Cargo.toml
@@ -7,10 +7,13 @@ build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-indradb-lib = { path = "../../lib" }
 serde_json = "^1.0.57"
 threadpool = "1.8.1"
 uuid = "~0.8.2"
 
 [build-dependencies]
 rustc_version = "0.4.0"
+
+[dependencies.indradb-lib]
+path = "../../lib"
+version = "3.0.0"

--- a/plugins/host/Cargo.toml
+++ b/plugins/host/Cargo.toml
@@ -10,7 +10,6 @@ keywords = ["graph", "database"]
 categories = ["database", "database-implementations"]
 license = "MPL-2.0"
 edition = "2021"
-readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -35,8 +35,15 @@ tokio = { version = "^1.11.0", features = ["rt-multi-thread"], optional = true }
 tokio-stream = { version = "0.1.7", features = ["net"], optional = true }
 libloading = { version = "0.7", optional = true }
 glob = { version = "0.3.0", optional = true }
-indradb-plugin-host = { path = "../plugins/host", optional = true }
-indradb-lib = { path = "../lib" }
+
+[dependencies.indradb-lib]
+path = "../lib"
+version = "3.0.0"
+
+[dependencies.indradb-plugin-host]
+path = "../plugins/host"
+version = "0.1.0"
+optional = true
 
 [build-dependencies]
 tonic-build = "0.5.2"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indradb-proto"
-version = "2.2.0"
+version = "3.0.0"
 authors = ["Yusuf Simonson <simonson@gmail.com>"]
 description = "Protobuf/gRPC interfaces for IndraDB"
 homepage = "https://indradb.github.io"

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -7,13 +7,12 @@ import time
 import subprocess
 
 VERSION_MATCHER = re.compile(r'^version = "([^"]+)\.([^"]+)\.([^"]+)"$')
-VERSIONED_CATEGORIES = {"[package]", "[dependencies.indradb-lib]", "[dependencies.indradb-proto]"}
 
 def run(args, cwd="."):
     print("%s => %s" % (cwd, args))
     subprocess.check_call(args, cwd=cwd)
 
-def update_version(path, new_version):
+def update_version(path, new_version, categories):
     with open(path, "r") as f:
         contents = f.read().splitlines()
 
@@ -21,7 +20,7 @@ def update_version(path, new_version):
 
     for i, line in enumerate(contents):
         if line.startswith("["):
-            in_appropriate_category = line in VERSIONED_CATEGORIES
+            in_appropriate_category = line in categories
         elif in_appropriate_category:
             match = VERSION_MATCHER.match(line)
 
@@ -33,6 +32,16 @@ def update_version(path, new_version):
     with open(path, "w") as f:
         f.write("\n".join(contents))
 
+def update_package_version(path, new_version):
+    update_version(path, new_version, {"[package]"})
+
+def update_dependency_versions(path, new_version):
+    update_version(path, new_version, {"[dependencies.indradb-lib]", "[dependencies.indradb-proto]"})
+
+def update_all_versions(path, new_version):
+    update_package_version(path, new_version)
+    update_dependency_versions(path, new_version)
+
 def main():
     if len(sys.argv) < 2:
         raise Exception("No version specified")
@@ -43,10 +52,11 @@ def main():
     except:
         raise Exception("Invalid version specification")
 
-    update_version("lib/Cargo.toml", new_version)
-    update_version("proto/Cargo.toml", new_version)
-    update_version("server/Cargo.toml", new_version)
-    update_version("client/Cargo.toml", new_version)
+    update_all_versions("lib/Cargo.toml", new_version)
+    update_all_versions("proto/Cargo.toml", new_version)
+    update_all_versions("server/Cargo.toml", new_version)
+    update_all_versions("client/Cargo.toml", new_version)
+    update_dependency_versions("plugin/host/Cargo.toml", new_version)
 
     run(["make", "check", "test"])
 
@@ -57,9 +67,9 @@ def main():
     run(["git", "push", "origin", new_version_str])
 
     run(["cargo", "publish"], cwd="lib")
+    run(["cargo", "publish"], cwd="plugins/host")
     time.sleep(15) # wait for lib to be accessible on crates.io
     run(["cargo", "publish"], cwd="proto")
-    run(["cargo", "publish"], cwd="plugins/host")
     time.sleep(15) # wait for proto to be accessible on crates.io
     run(["cargo", "publish"], cwd="server")
     run(["cargo", "publish"], cwd="client")

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -68,7 +68,7 @@ def main():
 
     run(["cargo", "publish"], cwd="lib")
     run(["cargo", "publish"], cwd="plugins/host")
-    time.sleep(15) # wait for lib to be accessible on crates.io
+    time.sleep(15) # wait for lib and plugin host to be accessible on crates.io
     run(["cargo", "publish"], cwd="proto")
     time.sleep(15) # wait for proto to be accessible on crates.io
     run(["cargo", "publish"], cwd="server")

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -19,8 +19,16 @@ path = "src/main.rs"
 clap = "2.33.3"
 tonic = "0.5.2"
 tokio = { version = "1.11.0", features = ["macros", "rt-multi-thread"] }
-indradb-lib = { path = "../lib", features = ["rocksdb-datastore"] }
-indradb-proto = { path = "../proto", features = ["server"] }
 
 [dev-dependencies]
 serde_json = "^1.0.57"
+
+[dependencies.indradb-lib]
+path = "../lib"
+version = "3.0.0"
+features = ["rocksdb-datastore"]
+
+[dependencies.indradb-proto]
+path = "../proto"
+version = "3.0.0"
+features = ["server"]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indradb"
-version = "2.2.0"
+version = "3.0.0"
 authors = ["Yusuf Simonson <simonson@gmail.com>"]
 description = "A graph database server"
 homepage = "https://indradb.github.io"


### PR DESCRIPTION
Some changes that were necessary for 3.0.0 to get published:

* Update the versions.
* Revert the removal of explicit versioning. It turns out explicit versioning is needed when publishing to crates.io.
* Added the ability for the plugin host to be published.