### PR TITLE
Use u64 for vertex IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,12 +153,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bumpalo"
-version = "3.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,21 +200,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-integer",
- "num-traits",
- "time",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
 name = "clang-sys"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,66 +223,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
-name = "cxx"
-version = "1.0.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -506,30 +416,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
-dependencies = [
- "cxx",
- "cxx-build",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,7 +455,6 @@ version = "3.0.4"
 dependencies = [
  "bincode",
  "byteorder",
- "chrono",
  "lazy_static",
  "rmp-serde",
  "rocksdb",
@@ -655,15 +540,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,15 +591,6 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -789,16 +656,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,12 +673,6 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "paste"
@@ -1111,12 +962,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
 
 [[package]]
-name = "scratch"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
-
-[[package]]
 name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,15 +1058,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,17 +1073,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -1526,60 +1351,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
-
-[[package]]
 name = "which"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,15 +1376,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,15 +56,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "atomic"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -162,6 +162,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bumpalo"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +215,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +253,66 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "cxx"
+version = "1.0.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -425,6 +506,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,7 +561,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tonic",
- "uuid",
 ]
 
 [[package]]
@@ -465,13 +569,13 @@ version = "3.0.4"
 dependencies = [
  "bincode",
  "byteorder",
+ "chrono",
  "lazy_static",
  "rmp-serde",
  "rocksdb",
  "serde",
  "serde_json",
  "tempfile",
- "uuid",
 ]
 
 [[package]]
@@ -491,7 +595,6 @@ dependencies = [
  "rustc_version",
  "serde_json",
  "threadpool",
- "uuid",
 ]
 
 [[package]]
@@ -519,7 +622,6 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-build",
- "uuid",
 ]
 
 [[package]]
@@ -550,6 +652,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -604,6 +715,15 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -669,6 +789,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +816,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "paste"
@@ -975,6 +1111,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
 
 [[package]]
+name = "scratch"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+
+[[package]]
 name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1213,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1237,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -1324,16 +1486,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
-name = "uuid"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
-dependencies = [
- "atomic",
- "serde",
-]
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1374,6 +1526,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
 name = "which"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,6 +1605,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/README.md
+++ b/README.md
@@ -39,15 +39,14 @@ Python bindings are available [here](https://github.com/indradb/python-client) a
 
 ```python
 import indradb
-import uuid
 
 # Connect to the server and make sure it's up
 client = indradb.Client("localhost:27615")
 client.ping()
 
 # Create a couple of vertices
-out_v = indradb.Vertex(uuid.uuid4(), "person")
-in_v = indradb.Vertex(uuid.uuid4(), "movie")
+out_v = indradb.Vertex(1, "person")
+in_v = indradb.Vertex(2, "movie")
 client.create_vertex(out_v)
 client.create_vertex(in_v)
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,7 +20,6 @@ clap = "2.34.0"
 tonic = "0.8.3"
 tokio = { version = "1.23.0", features = ["macros", "rt-multi-thread"] }
 serde_json = "1.0.91"
-uuid = { version = "1.2.2", features = ["serde"] }
 
 [dependencies.indradb-lib]
 path = "../lib"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,7 +23,6 @@ bench-suite = []
 
 [dependencies]
 byteorder = "^1.4.2"
-chrono = "0.4.23"
 serde = { version = "^1.0.57", features = ["derive"] }
 serde_json = "^1.0.57"
 lazy_static = "^1.4.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,12 +23,12 @@ bench-suite = []
 
 [dependencies]
 byteorder = "^1.4.2"
+chrono = "0.4.23"
 serde = { version = "^1.0.57", features = ["derive"] }
 serde_json = "^1.0.57"
 lazy_static = "^1.4.0"
 rmp-serde = "1.1.1"
 tempfile = "^3.2.0"
-uuid = { version = "^1.2.2", features = ["v1", "serde"] }
 
 # Rocksdb dependencies
 rocksdb = { version = "0.19.0", optional = true }

--- a/lib/fuzz/Cargo.lock
+++ b/lib/fuzz/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "arbitrary"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,12 +52,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "bumpalo"
-version = "3.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,21 +93,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-integer",
- "num-traits",
- "time",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
 name = "clang-sys"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,66 +101,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
-name = "cxx"
-version = "1.0.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -222,36 +132,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
-dependencies = [
- "cxx",
- "cxx-build",
-]
-
-[[package]]
 name = "indradb-lib"
 version = "3.0.4"
 dependencies = [
  "bincode",
  "byteorder",
- "chrono",
  "lazy_static",
  "rmp-serde",
  "rocksdb",
@@ -284,15 +169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b06c1b455f1cf4269a8cfc320ab930a810e2375a42af5075eb8a8b36405ce0"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
-dependencies = [
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -361,24 +237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "log"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "memchr"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,16 +256,6 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
 ]
 
 [[package]]
@@ -585,12 +433,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 
 [[package]]
-name = "scratch"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
-
-[[package]]
 name = "serde"
 version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,36 +495,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi",
- "winapi",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "vcpkg"
@@ -695,60 +511,6 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "winapi"
@@ -765,15 +527,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/lib/fuzz/Cargo.lock
+++ b/lib/fuzz/Cargo.lock
@@ -3,21 +3,21 @@
 version = 3
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29d47fbf90d5149a107494b15a7dc8d69b351be2db3bb9691740e88ec17fd880"
 dependencies = [
  "derive_arbitrary",
-]
-
-[[package]]
-name = "atomic"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -61,6 +61,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bumpalo"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +108,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +131,66 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "cxx"
+version = "1.0.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -141,18 +222,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "indradb-lib"
 version = "3.0.4"
 dependencies = [
  "bincode",
  "byteorder",
+ "chrono",
  "lazy_static",
  "rmp-serde",
  "rocksdb",
  "serde",
  "serde_json",
  "tempfile",
- "uuid",
 ]
 
 [[package]]
@@ -164,7 +269,6 @@ dependencies = [
  "libfuzzer-sys",
  "serde_json",
  "tempfile",
- "uuid",
 ]
 
 [[package]]
@@ -180,6 +284,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b06c1b455f1cf4269a8cfc320ab930a810e2375a42af5075eb8a8b36405ce0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -248,6 +361,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "memchr"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +398,16 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -319,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -444,6 +585,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 
 [[package]]
+name = "scratch"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+
+[[package]]
 name = "serde"
 version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,20 +653,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
-name = "uuid"
-version = "1.2.2"
+name = "unicode-width"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
-dependencies = [
- "atomic",
- "serde",
-]
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "vcpkg"
@@ -532,6 +695,60 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "winapi"
@@ -548,6 +765,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/lib/fuzz/Cargo.toml
+++ b/lib/fuzz/Cargo.toml
@@ -13,7 +13,6 @@ arbitrary = { version = "^1.2.0", features = ["derive"] }
 libfuzzer-sys = "0.4.5"
 serde_json = "^1.0.57"
 tempfile = "^3.2.0"
-uuid = { version = "^1.2.2", features = ["v1"] }
 
 [dependencies.indradb-lib]
 path = ".."

--- a/lib/fuzz/fuzz_targets/compare.rs
+++ b/lib/fuzz/fuzz_targets/compare.rs
@@ -22,7 +22,7 @@ pub enum Op {
 pub enum BulkInsertItem {
     Vertex(Vertex),
     Edge(Edge),
-    VertexProperty(Uuid, Identifier, Json),
+    VertexProperty(u64, Identifier, Json),
     EdgeProperty(Edge, Identifier, Json),
 }
 
@@ -43,7 +43,7 @@ impl Into<indradb::BulkInsertItem> for BulkInsertItem {
 
 #[derive(Arbitrary, Clone, Debug, PartialEq)]
 pub struct Vertex {
-    pub id: Uuid,
+    pub id: u64,
     pub t: Identifier,
 }
 
@@ -141,7 +141,7 @@ impl Into<indradb::Query> for Query {
 pub struct RangeVertexQuery {
     pub limit: u32,
     pub t: Option<Identifier>,
-    pub start_id: Option<Uuid>,
+    pub start_id: Option<u64>,
 }
 
 impl Into<indradb::RangeVertexQuery> for RangeVertexQuery {
@@ -156,7 +156,7 @@ impl Into<indradb::RangeVertexQuery> for RangeVertexQuery {
 
 #[derive(Arbitrary, Clone, Debug, PartialEq)]
 pub struct SpecificVertexQuery {
-    pub ids: Vec<Uuid>,
+    pub ids: Vec<u64>,
 }
 
 impl Into<indradb::SpecificVertexQuery> for SpecificVertexQuery {
@@ -334,7 +334,7 @@ impl Into<indradb::CountQuery> for CountQuery {
 
 #[derive(Arbitrary, Clone, Debug, PartialEq)]
 pub struct VertexProperty {
-    pub id: Uuid,
+    pub id: u64,
     pub value: Json,
 }
 
@@ -409,9 +409,9 @@ impl Into<indradb::EdgeProperty> for EdgeProperty {
 
 #[derive(Arbitrary, Clone, Debug, PartialEq)]
 pub struct Edge {
-    pub outbound_id: Uuid,
+    pub outbound_id: u64,
     pub t: Identifier,
-    pub inbound_id: Uuid,
+    pub inbound_id: u64,
 }
 
 impl Into<indradb::Edge> for Edge {
@@ -421,23 +421,6 @@ impl Into<indradb::Edge> for Edge {
             t: self.t.into(),
             inbound_id: self.inbound_id.into(),
         }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct Uuid(uuid::Uuid);
-
-impl<'a> Arbitrary<'a> for Uuid {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Self {
-            0: uuid::Uuid::from_u128(u.arbitrary()?),
-        })
-    }
-}
-
-impl Into<uuid::Uuid> for Uuid {
-    fn into(self) -> uuid::Uuid {
-        self.0
     }
 }
 

--- a/lib/fuzz/fuzz_targets/compare.rs
+++ b/lib/fuzz/fuzz_targets/compare.rs
@@ -49,7 +49,7 @@ pub struct Vertex {
 
 impl Into<indradb::Vertex> for Vertex {
     fn into(self) -> indradb::Vertex {
-        indradb::Vertex::with_id(self.id.into(), self.t.into())
+        indradb::Vertex::new(self.id.into(), self.t.into())
     }
 }
 

--- a/lib/src/errors.rs
+++ b/lib/src/errors.rs
@@ -13,8 +13,8 @@ use serde_json::Error as JsonError;
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum Error {
-    /// The requested UUID is already taken.
-    UuidTaken,
+    /// The requested ID is already taken.
+    IdTaken,
 
     /// An error occurred in the underlying datastore.
     Datastore(Box<dyn StdError + Send + Sync>),
@@ -46,7 +46,7 @@ impl StdError for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::UuidTaken => write!(f, "UUID already taken"),
+            Error::IdTaken => write!(f, "ID already taken"),
             Error::Datastore(ref err) => write!(f, "error in the underlying datastore: {}", err),
             Error::NotIndexed => write!(f, "query attempted on a property that isn't indexed"),
             Error::Unsupported => write!(f, "functionality not supported"),
@@ -98,8 +98,8 @@ pub enum ValidationError {
     InvalidValue,
     /// The value is too long.
     ValueTooLong,
-    /// The input UUID is the maximum value, and cannot be incremented.
-    CannotIncrementUuid,
+    /// The input ID is the maximum value, and cannot be incremented.
+    CannotIncrementId,
     /// The given query combination cannot be nested (e.g. attempting to build
     /// a query that gets vertex properties from a query that outputs a
     /// count.)
@@ -113,7 +113,7 @@ impl fmt::Display for ValidationError {
         match *self {
             ValidationError::InvalidValue => write!(f, "invalid value"),
             ValidationError::ValueTooLong => write!(f, "value too long"),
-            ValidationError::CannotIncrementUuid => write!(f, "could not increment the UUID"),
+            ValidationError::CannotIncrementId => write!(f, "could not increment the ID"),
             ValidationError::InnerQuery => write!(f, "the given query combination cannot be nested"),
         }
     }

--- a/lib/src/memory/datastore.rs
+++ b/lib/src/memory/datastore.rs
@@ -318,11 +318,11 @@ impl<'a> Transaction<'a> for MemoryTransaction<'a> {
         Ok(())
     }
 
-    fn max_id(&self) -> Result<u64> {
+    fn next_id(&self) -> Result<u64> {
         if let Some((k, _)) = self.internal.vertices.last_key_value() {
-            Ok(*k)
+            Ok(*k + 1)
         } else {
-            Ok(0)
+            Ok(1)
         }
     }
 

--- a/lib/src/memory/datastore.rs
+++ b/lib/src/memory/datastore.rs
@@ -57,7 +57,7 @@ impl<'a> Transaction<'a> for MemoryTransaction<'a> {
             .internal
             .vertices
             .iter()
-            .map(|(id, t)| Ok(Vertex::with_id(*id, t.clone())));
+            .map(|(id, t)| Ok(Vertex::new(*id, t.clone())));
         Ok(Box::new(iter))
     }
 
@@ -66,7 +66,7 @@ impl<'a> Transaction<'a> for MemoryTransaction<'a> {
             .internal
             .vertices
             .range(offset..)
-            .map(|(id, t)| Ok(Vertex::with_id(*id, t.clone())));
+            .map(|(id, t)| Ok(Vertex::new(*id, t.clone())));
         Ok(Box::new(iter))
     }
 
@@ -75,7 +75,7 @@ impl<'a> Transaction<'a> for MemoryTransaction<'a> {
             self.internal
                 .vertices
                 .get(&id)
-                .map(|value| Ok(Vertex::with_id(id, value.clone())))
+                .map(|value| Ok(Vertex::new(id, value.clone())))
         });
         Ok(Box::new(iter))
     }
@@ -316,6 +316,14 @@ impl<'a> Transaction<'a> for MemoryTransaction<'a> {
                 .map_err(|err| Error::Datastore(Box::new(err)))?;
         }
         Ok(())
+    }
+
+    fn max_id(&self) -> Result<u64> {
+        if let Some((k, _)) = self.internal.vertices.last_key_value() {
+            Ok(*k)
+        } else {
+            Ok(0)
+        }
     }
 
     fn create_vertex(&mut self, vertex: &Vertex) -> Result<bool> {

--- a/lib/src/memory/mod.rs
+++ b/lib/src/memory/mod.rs
@@ -18,11 +18,10 @@ mod tests {
     use crate::{AllVertexQuery, CountQueryExt, Database, Identifier, SpecificVertexQuery};
 
     use tempfile::NamedTempFile;
-    use uuid::Uuid;
 
     full_test_impl!(MemoryDatastore::new_db());
 
-    fn create_vertex_with_property(db: &Database<MemoryDatastore>) -> Uuid {
+    fn create_vertex_with_property(db: &Database<MemoryDatastore>) -> u64 {
         let id = db.create_vertex_from_type(Identifier::default()).unwrap();
         db.set_properties(
             SpecificVertexQuery::single(id),
@@ -33,7 +32,7 @@ mod tests {
         id
     }
 
-    fn expect_vertex(db: &Database<MemoryDatastore>, id: Uuid) {
+    fn expect_vertex(db: &Database<MemoryDatastore>, id: u64) {
         assert_eq!(extract_count(db.get(AllVertexQuery.count().unwrap()).unwrap()), Some(1));
         let vertices = extract_vertices(db.get(SpecificVertexQuery::new(vec![id])).unwrap()).unwrap();
         assert_eq!(vertices.len(), 1);

--- a/lib/src/models/bulk_insert.rs
+++ b/lib/src/models/bulk_insert.rs
@@ -1,7 +1,5 @@
 use crate::{Edge, Identifier, Vertex};
 
-use uuid::Uuid;
-
 /// An item to insert, as part of a bulk insert request.
 #[derive(Clone, Debug, PartialEq)]
 pub enum BulkInsertItem {
@@ -10,7 +8,7 @@ pub enum BulkInsertItem {
     /// An edge to insert.
     Edge(Edge),
     /// A vertex property to insert.
-    VertexProperty(Uuid, Identifier, serde_json::Value),
+    VertexProperty(u64, Identifier, serde_json::Value),
     /// An edge property to insert.
     EdgeProperty(Edge, Identifier, serde_json::Value),
 }

--- a/lib/src/models/edges.rs
+++ b/lib/src/models/edges.rs
@@ -1,7 +1,6 @@
 use super::Identifier;
 
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 /// An edge.
 ///
@@ -11,13 +10,13 @@ use uuid::Uuid;
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct Edge {
     /// The id of the outbound vertex.
-    pub outbound_id: Uuid,
+    pub outbound_id: u64,
 
     /// The type of the edge.
     pub t: Identifier,
 
     /// The id of the inbound vertex.
-    pub inbound_id: Uuid,
+    pub inbound_id: u64,
 }
 
 impl Edge {
@@ -28,7 +27,7 @@ impl Edge {
     /// * `outbound_id`: The id of the outbound vertex.
     /// * `t`: The type of the edge.
     /// * `inbound_id`: The id of the inbound vertex.
-    pub fn new(outbound_id: Uuid, t: Identifier, inbound_id: Uuid) -> Edge {
+    pub fn new(outbound_id: u64, t: Identifier, inbound_id: u64) -> Edge {
         Edge {
             outbound_id,
             t,

--- a/lib/src/models/properties.rs
+++ b/lib/src/models/properties.rs
@@ -1,12 +1,10 @@
 use crate::{Edge, Identifier, Vertex};
 
-use uuid::Uuid;
-
 /// Represents a vertex property.
 #[derive(Clone, Debug, PartialEq)]
 pub struct VertexProperty {
     /// The id of the vertex.
-    pub id: Uuid,
+    pub id: u64,
 
     /// The property value.
     pub value: serde_json::Value,
@@ -18,7 +16,7 @@ impl VertexProperty {
     /// # Arguments
     /// * `id`: The id of the vertex.
     /// * `value`: The property value.
-    pub fn new(id: Uuid, value: serde_json::Value) -> Self {
+    pub fn new(id: u64, value: serde_json::Value) -> Self {
         Self { id, value }
     }
 }

--- a/lib/src/models/queries.rs
+++ b/lib/src/models/queries.rs
@@ -3,8 +3,6 @@ use std::u32;
 
 use crate::{errors, Edge, Identifier};
 
-use uuid::Uuid;
-
 macro_rules! into_query {
     ($name:ident, $variant:ident) => {
         // we don't want to impl From since the reverse operation isn't allowed
@@ -250,7 +248,7 @@ pub struct RangeVertexQuery {
     pub t: Option<Identifier>,
 
     /// Sets the lowest vertex ID to return.
-    pub start_id: Option<Uuid>,
+    pub start_id: Option<u64>,
 }
 
 nestable_query!(RangeVertexQuery, RangeVertex);
@@ -299,7 +297,7 @@ impl RangeVertexQuery {
     ///
     /// # Arguments
     /// * `start_id`: The lowest vertex ID to return.
-    pub fn start_id(self, start_id: Uuid) -> Self {
+    pub fn start_id(self, start_id: u64) -> Self {
         Self {
             limit: self.limit,
             t: self.t,
@@ -312,7 +310,7 @@ impl RangeVertexQuery {
 #[derive(Eq, PartialEq, Clone, Debug)]
 pub struct SpecificVertexQuery {
     /// The IDs of the vertices to get.
-    pub ids: Vec<Uuid>,
+    pub ids: Vec<u64>,
 }
 
 nestable_query!(SpecificVertexQuery, SpecificVertex);
@@ -323,7 +321,7 @@ impl SpecificVertexQuery {
     ///
     /// Arguments
     /// * `ids`: The IDs of the vertices to get.
-    pub fn new(ids: Vec<Uuid>) -> Self {
+    pub fn new(ids: Vec<u64>) -> Self {
         Self { ids }
     }
 
@@ -331,7 +329,7 @@ impl SpecificVertexQuery {
     ///
     /// Arguments
     /// * `id`: The ID of the vertex to get.
-    pub fn single(id: Uuid) -> Self {
+    pub fn single(id: u64) -> Self {
         Self { ids: vec![id] }
     }
 }

--- a/lib/src/models/vertices.rs
+++ b/lib/src/models/vertices.rs
@@ -1,16 +1,6 @@
 use crate::Identifier;
 
 use std::hash::{Hash, Hasher};
-use std::sync::atomic::{AtomicU64, Ordering};
-
-use chrono::Utc;
-use lazy_static::lazy_static;
-
-lazy_static! {
-    static ref INIT_TIMESTAMP: u64 = Utc::now().timestamp_nanos() as u64;
-}
-
-static OFFSET: AtomicU64 = AtomicU64::new(1);
 
 /// A vertex.
 ///
@@ -29,18 +19,9 @@ impl Vertex {
     /// Creates a new vertex.
     ///
     /// # Arguments
-    /// * `t`: The type of the vertex.
-    pub fn new(t: Identifier) -> Self {
-        let id = *INIT_TIMESTAMP + OFFSET.fetch_add(1, Ordering::Relaxed);
-        Self::with_id(id, t)
-    }
-
-    /// Creates a new vertex with a specified id.
-    ///
-    /// # Arguments
     /// * `id`: The id of the vertex.
     /// * `t`: The type of the vertex.
-    pub fn with_id(id: u64, t: Identifier) -> Self {
+    pub fn new(id: u64, t: Identifier) -> Self {
         Vertex { id, t }
     }
 }
@@ -68,8 +49,8 @@ mod tests {
     #[test]
     fn should_hash() {
         assert_eq!(
-            HashSet::from([Vertex::with_id(0, Identifier::new("foo").unwrap())]),
-            HashSet::from([Vertex::with_id(0, Identifier::new("foo").unwrap())])
+            HashSet::from([Vertex::new(0, Identifier::new("foo").unwrap())]),
+            HashSet::from([Vertex::new(0, Identifier::new("foo").unwrap())])
         );
     }
 }

--- a/lib/src/rdb/datastore.rs
+++ b/lib/src/rdb/datastore.rs
@@ -93,7 +93,7 @@ impl<'a> Transaction<'a> for RocksdbTransaction<'a> {
 
     fn specific_vertices(&'a self, ids: Vec<u64>) -> Result<DynIter<'a, Vertex>> {
         let iter = ids.into_iter().filter_map(move |id| match self.vertex_manager.get(id) {
-            Ok(Some(t)) => Some(Ok(Vertex::with_id(id, t))),
+            Ok(Some(t)) => Some(Ok(Vertex::new(id, t))),
             Ok(None) => None,
             Err(err) => Some(Err(err)),
         });
@@ -291,6 +291,10 @@ impl<'a> Transaction<'a> for RocksdbTransaction<'a> {
         self.metadata_manager.compact();
         self.db.flush()?;
         Ok(())
+    }
+
+    fn max_id(&self) -> Result<u64> {
+        self.vertex_manager.max_id()
     }
 
     fn create_vertex(&mut self, vertex: &Vertex) -> Result<bool> {

--- a/lib/src/rdb/managers.rs
+++ b/lib/src/rdb/managers.rs
@@ -68,7 +68,7 @@ impl<'a> VertexManager<'a> {
             let (k, v) = item?;
 
             let id = {
-                debug_assert_eq!(k.len(), 16);
+                debug_assert_eq!(k.len(), 8);
                 let mut cursor = Cursor::new(k);
                 util::read_u64(&mut cursor)
             };

--- a/lib/src/tests/bulk_insert.rs
+++ b/lib/src/tests/bulk_insert.rs
@@ -5,8 +5,8 @@ use crate::{
 
 pub fn should_bulk_insert<D: Datastore>(db: &Database<D>) {
     let vertex_t = Identifier::new("test_vertex_type").unwrap();
-    let outbound_v = Vertex::new(vertex_t.clone());
-    let inbound_v = Vertex::new(vertex_t);
+    let outbound_v = Vertex::new(1_000_000, vertex_t.clone());
+    let inbound_v = Vertex::new(1_000_001, vertex_t);
 
     let items = vec![
         BulkInsertItem::Vertex(outbound_v.clone()),
@@ -85,11 +85,8 @@ pub fn should_bulk_insert<D: Datastore>(db: &Database<D>) {
 // Bulk insert allows for redundant vertex insertion
 pub fn should_bulk_insert_a_redundant_vertex<D: Datastore>(db: &Database<D>) {
     let vertex_t = Identifier::new("test_vertex_type").unwrap();
-    let vertex = Vertex::new(vertex_t);
-
-    assert!(db.create_vertex(&vertex).unwrap());
-
-    let items = vec![BulkInsertItem::Vertex(vertex)];
+    let id = db.create_vertex_from_type(vertex_t.clone()).unwrap();
+    let items = vec![BulkInsertItem::Vertex(Vertex::new(id, vertex_t))];
     assert!(db.bulk_insert(items).is_ok());
 }
 
@@ -97,15 +94,13 @@ pub fn should_bulk_insert_a_redundant_vertex<D: Datastore>(db: &Database<D>) {
 // associated with an inserted edge exist; this verifies that
 pub fn should_bulk_insert_an_invalid_edge<D: Datastore>(db: &Database<D>) {
     let vertex_t = Identifier::new("test_vertex_type").unwrap();
-    let v1 = Vertex::new(vertex_t.clone());
-    let v2 = Vertex::new(vertex_t);
-
-    assert!(db.create_vertex(&v1).unwrap());
+    let v1_id = db.create_vertex_from_type(vertex_t.clone()).unwrap();
+    let v2 = Vertex::new(u64::max_value(), vertex_t);
 
     let edge_t = Identifier::new("test_edge_type").unwrap();
 
-    let items = vec![BulkInsertItem::Edge(Edge::new(v1.id, edge_t.clone(), v2.id))];
+    let items = vec![BulkInsertItem::Edge(Edge::new(v1_id, edge_t.clone(), v2.id))];
     assert!(db.bulk_insert(items).is_ok());
-    let items = vec![BulkInsertItem::Edge(Edge::new(v2.id, edge_t, v1.id))];
+    let items = vec![BulkInsertItem::Edge(Edge::new(v2.id, edge_t, v1_id))];
     assert!(db.bulk_insert(items).is_ok());
 }

--- a/lib/src/tests/edge.rs
+++ b/lib/src/tests/edge.rs
@@ -19,50 +19,40 @@ pub fn should_get_all_edges<D: Datastore>(db: &Database<D>) {
 
 pub fn should_get_a_valid_edge<D: Datastore>(db: &Database<D>) {
     let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
-    let outbound_v = models::Vertex::new(vertex_t.clone());
-    let inbound_v = models::Vertex::new(vertex_t);
-    db.create_vertex(&outbound_v).unwrap();
-    db.create_vertex(&inbound_v).unwrap();
+    let outbound_id = db.create_vertex_from_type(vertex_t.clone()).unwrap();
+    let inbound_id = db.create_vertex_from_type(vertex_t).unwrap();
     let edge_t = models::Identifier::new("test_edge_type").unwrap();
-    let edge = models::Edge::new(outbound_v.id, edge_t.clone(), inbound_v.id);
+    let edge = models::Edge::new(outbound_id, edge_t.clone(), inbound_id);
 
     db.create_edge(&edge).unwrap();
 
     let e = util::get_edges(db, SpecificEdgeQuery::single(edge)).unwrap();
     assert_eq!(e.len(), 1);
-    assert_eq!(e[0].outbound_id, outbound_v.id);
+    assert_eq!(e[0].outbound_id, outbound_id);
     assert_eq!(e[0].t, edge_t);
-    assert_eq!(e[0].inbound_id, inbound_v.id);
+    assert_eq!(e[0].inbound_id, inbound_id);
 }
 
 pub fn should_not_get_an_invalid_edge<D: Datastore>(db: &Database<D>) {
     let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
-    let outbound_v = models::Vertex::new(vertex_t.clone());
-    let inbound_v = models::Vertex::new(vertex_t);
-    db.create_vertex(&outbound_v).unwrap();
-    db.create_vertex(&inbound_v).unwrap();
+    let outbound_id = db.create_vertex_from_type(vertex_t.clone()).unwrap();
+    let inbound_id = db.create_vertex_from_type(vertex_t).unwrap();
     let edge_t = models::Identifier::new("test_edge_type").unwrap();
 
-    let e = util::get_edges(
-        db,
-        SpecificEdgeQuery::single(Edge::new(outbound_v.id, edge_t.clone(), 0)),
-    )
-    .unwrap();
+    let e = util::get_edges(db, SpecificEdgeQuery::single(Edge::new(outbound_id, edge_t.clone(), 0))).unwrap();
     assert_eq!(e.len(), 0);
-    let e = util::get_edges(db, SpecificEdgeQuery::single(Edge::new(0, edge_t, inbound_v.id))).unwrap();
+    let e = util::get_edges(db, SpecificEdgeQuery::single(Edge::new(0, edge_t, inbound_id))).unwrap();
     assert_eq!(e.len(), 0);
 }
 
 pub fn should_create_a_valid_edge<D: Datastore>(db: &Database<D>) {
     let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
-    let outbound_v = models::Vertex::new(vertex_t.clone());
-    let inbound_v = models::Vertex::new(vertex_t);
-    db.create_vertex(&outbound_v).unwrap();
-    db.create_vertex(&inbound_v).unwrap();
+    let outbound_id = db.create_vertex_from_type(vertex_t.clone()).unwrap();
+    let inbound_id = db.create_vertex_from_type(vertex_t).unwrap();
     let edge_t = models::Identifier::new("test_edge_type").unwrap();
 
     // Set the edge and check
-    let edge = models::Edge::new(outbound_v.id, edge_t, inbound_v.id);
+    let edge = models::Edge::new(outbound_id, edge_t, inbound_id);
     db.create_edge(&edge).unwrap();
     let e = util::get_edges(db, SpecificEdgeQuery::single(edge.clone())).unwrap();
     assert_eq!(e.len(), 1);
@@ -81,7 +71,7 @@ pub fn should_create_a_valid_edge<D: Datastore>(db: &Database<D>) {
     // single edge
     let e = util::get_edges(
         db,
-        SpecificVertexQuery::single(outbound_v.id).outbound().unwrap().limit(10),
+        SpecificVertexQuery::single(outbound_id).outbound().unwrap().limit(10),
     )
     .unwrap();
     assert_eq!(e.len(), 1);
@@ -90,23 +80,20 @@ pub fn should_create_a_valid_edge<D: Datastore>(db: &Database<D>) {
 
 pub fn should_not_create_an_invalid_edge<D: Datastore>(db: &Database<D>) {
     let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
-    let outbound_v = models::Vertex::new(vertex_t);
-    db.create_vertex(&outbound_v).unwrap();
+    let outbound_id = db.create_vertex_from_type(vertex_t).unwrap();
     let edge_t = models::Identifier::new("test_edge_type").unwrap();
-    let edge = models::Edge::new(outbound_v.id, edge_t, 0);
+    let edge = models::Edge::new(outbound_id, edge_t, 0);
     let result = db.create_edge(&edge);
     assert_eq!(result.unwrap(), false);
 }
 
 pub fn should_delete_a_valid_edge<D: Datastore>(db: &Database<D>) {
     let vertex_t = models::Identifier::new("test_edge_type").unwrap();
-    let outbound_v = models::Vertex::new(vertex_t.clone());
-    let inbound_v = models::Vertex::new(vertex_t);
-    db.create_vertex(&outbound_v).unwrap();
-    db.create_vertex(&inbound_v).unwrap();
+    let outbound_id = db.create_vertex_from_type(vertex_t.clone()).unwrap();
+    let inbound_id = db.create_vertex_from_type(vertex_t).unwrap();
 
     let edge_t = models::Identifier::new("test_edge_type").unwrap();
-    let edge = models::Edge::new(outbound_v.id, edge_t, inbound_v.id);
+    let edge = models::Edge::new(outbound_id, edge_t, inbound_id);
     db.create_edge(&edge).unwrap();
 
     let q = SpecificEdgeQuery::single(edge);
@@ -123,11 +110,11 @@ pub fn should_delete_a_valid_edge<D: Datastore>(db: &Database<D>) {
 }
 
 pub fn should_not_delete_an_invalid_edge<D: Datastore>(db: &Database<D>) {
-    let vertex_t = models::Identifier::new("test_edge_type").unwrap();
-    let outbound_v = models::Vertex::new(vertex_t);
-    db.create_vertex(&outbound_v).unwrap();
+    let outbound_id = db
+        .create_vertex_from_type(models::Identifier::new("test_edge_type").unwrap())
+        .unwrap();
     let edge_t = models::Identifier::new("test_edge_type").unwrap();
-    db.delete(SpecificEdgeQuery::single(Edge::new(outbound_v.id, edge_t, 0)))
+    db.delete(SpecificEdgeQuery::single(Edge::new(outbound_id, edge_t, 0)))
         .unwrap();
 }
 
@@ -196,13 +183,12 @@ pub fn should_get_edges<D: Datastore>(db: &Database<D>) {
 }
 
 pub fn should_get_edges_piped<D: Datastore>(db: &Database<D>) {
-    let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
-    let outbound_v = models::Vertex::new(vertex_t);
-    db.create_vertex(&outbound_v).unwrap();
+    let outbound_id = db
+        .create_vertex_from_type(models::Identifier::new("test_vertex_type").unwrap())
+        .unwrap();
+    let inbound_id = util::create_edge_from(db, outbound_id);
 
-    let inbound_id = util::create_edge_from(db, outbound_v.id);
-
-    let query_1 = SpecificVertexQuery::single(outbound_v.id)
+    let query_1 = SpecificVertexQuery::single(outbound_id)
         .outbound()
         .unwrap()
         .limit(1)
@@ -212,7 +198,7 @@ pub fn should_get_edges_piped<D: Datastore>(db: &Database<D>) {
     assert_eq!(
         range[0],
         models::Edge::new(
-            outbound_v.id,
+            outbound_id,
             models::Identifier::new("test_edge_type").unwrap(),
             inbound_id
         )
@@ -231,7 +217,7 @@ pub fn should_get_edges_piped<D: Datastore>(db: &Database<D>) {
     assert_eq!(
         range[0],
         models::Edge::new(
-            outbound_v.id,
+            outbound_id,
             models::Identifier::new("test_edge_type").unwrap(),
             inbound_id
         )

--- a/lib/src/tests/include_query.rs
+++ b/lib/src/tests/include_query.rs
@@ -17,7 +17,7 @@ pub fn should_get_nested_include_query<D: Datastore>(db: &Database<D>) {
     assert_eq!(
         output,
         vec![
-            QueryOutputValue::Vertices(vec![Vertex::with_id(
+            QueryOutputValue::Vertices(vec![Vertex::new(
                 outbound_id,
                 Identifier::new("test_outbound_vertex_type").unwrap()
             )]),
@@ -45,9 +45,9 @@ pub fn should_get_unnested_include_query<D: Datastore>(db: &Database<D>) {
     assert_eq!(
         output,
         vec![
-            QueryOutputValue::Vertices(vec![Vertex::with_id(id, Identifier::new("foo").unwrap())]),
+            QueryOutputValue::Vertices(vec![Vertex::new(id, Identifier::new("foo").unwrap())]),
             QueryOutputValue::VertexProperties(vec![VertexProperties::new(
-                Vertex::with_id(id, Identifier::new("foo").unwrap()),
+                Vertex::new(id, Identifier::new("foo").unwrap()),
                 vec![NamedProperty::new(
                     Identifier::new("bar").unwrap(),
                     serde_json::Value::Bool(true)
@@ -78,8 +78,8 @@ pub fn should_include_with_property_presence<D: Datastore>(db: &Database<D>) {
     assert_eq!(
         output,
         vec![
-            QueryOutputValue::Vertices(vec![Vertex::with_id(id, Identifier::new("foo").unwrap())]),
-            QueryOutputValue::Vertices(vec![Vertex::with_id(id, Identifier::new("foo").unwrap())]),
+            QueryOutputValue::Vertices(vec![Vertex::new(id, Identifier::new("foo").unwrap())]),
+            QueryOutputValue::Vertices(vec![Vertex::new(id, Identifier::new("foo").unwrap())]),
         ]
     );
     let output = db
@@ -92,8 +92,8 @@ pub fn should_include_with_property_presence<D: Datastore>(db: &Database<D>) {
     assert_eq!(
         output,
         vec![
-            QueryOutputValue::Vertices(vec![Vertex::with_id(id, Identifier::new("foo").unwrap())]),
-            QueryOutputValue::Vertices(vec![Vertex::with_id(id, Identifier::new("foo").unwrap())]),
+            QueryOutputValue::Vertices(vec![Vertex::new(id, Identifier::new("foo").unwrap())]),
+            QueryOutputValue::Vertices(vec![Vertex::new(id, Identifier::new("foo").unwrap())]),
         ]
     );
 }

--- a/lib/src/tests/indexing.rs
+++ b/lib/src/tests/indexing.rs
@@ -1,8 +1,7 @@
 use super::util;
 use crate::{expect_err, models, Database, Datastore, Error, QueryExt};
-use uuid::Uuid;
 
-fn setup_vertex_with_indexed_property<D: Datastore>(db: &Database<D>, property_name: &models::Identifier) -> Uuid {
+fn setup_vertex_with_indexed_property<D: Datastore>(db: &Database<D>, property_name: &models::Identifier) -> u64 {
     db.index_property(property_name.clone()).unwrap();
     let v = models::Vertex::new(models::Identifier::new("test_vertex_type").unwrap());
     db.create_vertex(&v).unwrap();

--- a/lib/src/tests/properties.rs
+++ b/lib/src/tests/properties.rs
@@ -2,14 +2,13 @@ use super::util;
 use crate::util::extract_count;
 use crate::{
     errors, expect_err, AllVertexQuery, CountQueryExt, Database, Datastore, Edge, Identifier, PipePropertyQuery,
-    PipeWithPropertyPresenceQuery, QueryExt, SpecificEdgeQuery, SpecificVertexQuery, Vertex,
+    PipeWithPropertyPresenceQuery, QueryExt, SpecificEdgeQuery, SpecificVertexQuery,
 };
 
 pub fn should_handle_vertex_properties<D: Datastore>(db: &Database<D>) {
     let t = Identifier::new("test_vertex_type").unwrap();
-    let v = Vertex::new(t);
-    db.create_vertex(&v).unwrap();
-    let q = SpecificVertexQuery::single(v.id);
+    let id = db.create_vertex_from_type(t).unwrap();
+    let q = SpecificVertexQuery::single(id);
 
     // Check to make sure there's no initial value
     let result = util::get_vertex_properties(
@@ -32,7 +31,7 @@ pub fn should_handle_vertex_properties<D: Datastore>(db: &Database<D>) {
     )
     .unwrap();
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].id, v.id);
+    assert_eq!(result[0].id, id);
     assert_eq!(result[0].value, serde_json::Value::Bool(true));
 
     // Set and get the value as false
@@ -48,7 +47,7 @@ pub fn should_handle_vertex_properties<D: Datastore>(db: &Database<D>) {
     )
     .unwrap();
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].id, v.id);
+    assert_eq!(result[0].id, id);
     assert_eq!(result[0].value, serde_json::Value::Bool(false));
 
     // Delete & check that it's deleted
@@ -61,15 +60,12 @@ pub fn should_handle_vertex_properties<D: Datastore>(db: &Database<D>) {
 
 pub fn should_get_all_vertex_properties<D: Datastore>(db: &Database<D>) {
     let t = Identifier::new("a_vertex").unwrap();
-    let v1 = &Vertex::new(t.clone());
-    let v2 = &Vertex::new(t.clone());
-    let v3 = &Vertex::new(t);
-    db.create_vertex(v1).unwrap();
-    db.create_vertex(v2).unwrap();
-    db.create_vertex(v3).unwrap();
-    let q1 = SpecificVertexQuery::single(v1.id);
-    let q2 = SpecificVertexQuery::single(v2.id);
-    let q3 = SpecificVertexQuery::single(v3.id);
+    let v1 = db.create_vertex_from_type(t.clone()).unwrap();
+    let v2 = db.create_vertex_from_type(t.clone()).unwrap();
+    let v3 = db.create_vertex_from_type(t.clone()).unwrap();
+    let q1 = SpecificVertexQuery::single(v1);
+    let q2 = SpecificVertexQuery::single(v2);
+    let q3 = SpecificVertexQuery::single(v3);
 
     // Check to make sure there are no initial properties
     let all_result = util::get_all_vertex_properties(db, q2.clone()).unwrap();
@@ -116,10 +112,9 @@ pub fn should_not_delete_invalid_vertex_properties<D: Datastore>(db: &Database<D
         .name(Identifier::new("foo").unwrap());
     db.delete(q).unwrap();
 
-    let v = Vertex::new(Identifier::new("foo").unwrap());
-    db.create_vertex(&v).unwrap();
+    let id = db.create_vertex_from_type(Identifier::new("foo").unwrap()).unwrap();
 
-    let q = SpecificVertexQuery::single(v.id)
+    let q = SpecificVertexQuery::single(id)
         .properties()
         .unwrap()
         .name(Identifier::new("foo").unwrap());
@@ -128,12 +123,10 @@ pub fn should_not_delete_invalid_vertex_properties<D: Datastore>(db: &Database<D
 
 pub fn should_handle_edge_properties<D: Datastore>(db: &Database<D>) {
     let vertex_t = Identifier::new("test_vertex_type").unwrap();
-    let outbound_v = Vertex::new(vertex_t.clone());
-    let inbound_v = Vertex::new(vertex_t);
-    db.create_vertex(&outbound_v).unwrap();
-    db.create_vertex(&inbound_v).unwrap();
+    let outbound_id = db.create_vertex_from_type(vertex_t.clone()).unwrap();
+    let inbound_id = db.create_vertex_from_type(vertex_t).unwrap();
     let edge_t = Identifier::new("test_edge_type").unwrap();
-    let edge = Edge::new(outbound_v.id, edge_t, inbound_v.id);
+    let edge = Edge::new(outbound_id, edge_t, inbound_id);
     let q = SpecificEdgeQuery::single(edge.clone());
 
     db.create_edge(&edge).unwrap();
@@ -199,12 +192,10 @@ pub fn should_handle_edge_properties<D: Datastore>(db: &Database<D>) {
 
 pub fn should_get_all_edge_properties<D: Datastore>(db: &Database<D>) {
     let vertex_t = Identifier::new("test_vertex_type").unwrap();
-    let outbound_v = Vertex::new(vertex_t.clone());
-    let inbound_v = Vertex::new(vertex_t);
-    db.create_vertex(&outbound_v).unwrap();
-    db.create_vertex(&inbound_v).unwrap();
+    let outbound_id = db.create_vertex_from_type(vertex_t.clone()).unwrap();
+    let inbound_id = db.create_vertex_from_type(vertex_t).unwrap();
     let edge_t = Identifier::new("test_edge_type").unwrap();
-    let edge = Edge::new(outbound_v.id, edge_t, inbound_v.id);
+    let edge = Edge::new(outbound_id, edge_t, inbound_id);
     let eq = SpecificEdgeQuery::single(edge.clone());
 
     db.create_edge(&edge).unwrap();
@@ -274,12 +265,10 @@ pub fn should_not_delete_invalid_edge_properties<D: Datastore>(db: &Database<D>)
     )
     .unwrap();
 
-    let outbound_v = Vertex::new(Identifier::new("foo").unwrap());
-    let inbound_v = Vertex::new(Identifier::new("foo").unwrap());
-    db.create_vertex(&outbound_v).unwrap();
-    db.create_vertex(&inbound_v).unwrap();
+    let outbound_id = db.create_vertex_from_type(Identifier::new("foo").unwrap()).unwrap();
+    let inbound_id = db.create_vertex_from_type(Identifier::new("foo").unwrap()).unwrap();
 
-    let edge = Edge::new(outbound_v.id, Identifier::new("baz").unwrap(), inbound_v.id);
+    let edge = Edge::new(outbound_id, Identifier::new("baz").unwrap(), inbound_id);
     db.create_edge(&edge).unwrap();
     db.delete(
         SpecificEdgeQuery::single(edge)
@@ -292,9 +281,8 @@ pub fn should_not_delete_invalid_edge_properties<D: Datastore>(db: &Database<D>)
 
 pub fn should_get_an_edge_properties_count<D: Datastore>(db: &Database<D>) {
     let vertex_t = Identifier::new("test_vertex_type").unwrap();
-    let v = Vertex::new(vertex_t);
-    db.create_vertex(&v).unwrap();
-    let q = SpecificVertexQuery::single(v.id);
+    let id = db.create_vertex_from_type(vertex_t).unwrap();
+    let q = SpecificVertexQuery::single(id);
     let count = extract_count(
         db.get(q.outbound().unwrap().properties().unwrap().count().unwrap())
             .unwrap(),
@@ -305,9 +293,8 @@ pub fn should_get_an_edge_properties_count<D: Datastore>(db: &Database<D>) {
 
 pub fn should_get_a_vertex_properties_count<D: Datastore>(db: &Database<D>) {
     let vertex_t = Identifier::new("test_vertex_type").unwrap();
-    let v = Vertex::new(vertex_t);
-    db.create_vertex(&v).unwrap();
-    let q = SpecificVertexQuery::single(v.id);
+    let id = db.create_vertex_from_type(vertex_t).unwrap();
+    let q = SpecificVertexQuery::single(id);
     db.set_properties(
         q.clone(),
         Identifier::new("foo").unwrap(),

--- a/lib/src/tests/properties.rs
+++ b/lib/src/tests/properties.rs
@@ -5,8 +5,6 @@ use crate::{
     PipeWithPropertyPresenceQuery, QueryExt, SpecificEdgeQuery, SpecificVertexQuery, Vertex,
 };
 
-use uuid::Uuid;
-
 pub fn should_handle_vertex_properties<D: Datastore>(db: &Database<D>) {
     let t = Identifier::new("test_vertex_type").unwrap();
     let v = Vertex::new(t);
@@ -103,7 +101,7 @@ pub fn should_get_all_vertex_properties<D: Datastore>(db: &Database<D>) {
 }
 
 pub fn should_not_set_invalid_vertex_properties<D: Datastore>(db: &Database<D>) {
-    let q = SpecificVertexQuery::single(Uuid::default());
+    let q = SpecificVertexQuery::single(0);
     db.set_properties(q.clone(), Identifier::new("foo").unwrap(), serde_json::Value::Null)
         .unwrap();
     let result =
@@ -112,7 +110,7 @@ pub fn should_not_set_invalid_vertex_properties<D: Datastore>(db: &Database<D>) 
 }
 
 pub fn should_not_delete_invalid_vertex_properties<D: Datastore>(db: &Database<D>) {
-    let q = SpecificVertexQuery::single(Uuid::default())
+    let q = SpecificVertexQuery::single(0)
         .properties()
         .unwrap()
         .name(Identifier::new("foo").unwrap());
@@ -258,7 +256,7 @@ pub fn should_get_all_edge_properties<D: Datastore>(db: &Database<D>) {
 }
 
 pub fn should_not_set_invalid_edge_properties<D: Datastore>(db: &Database<D>) {
-    let edge = Edge::new(Uuid::default(), Identifier::new("foo").unwrap(), Uuid::default());
+    let edge = Edge::new(0, Identifier::new("foo").unwrap(), 0);
     let q = SpecificEdgeQuery::single(edge);
     db.set_properties(q.clone(), Identifier::new("bar").unwrap(), serde_json::Value::Null)
         .unwrap();
@@ -267,7 +265,7 @@ pub fn should_not_set_invalid_edge_properties<D: Datastore>(db: &Database<D>) {
 }
 
 pub fn should_not_delete_invalid_edge_properties<D: Datastore>(db: &Database<D>) {
-    let edge = Edge::new(Uuid::default(), Identifier::new("foo").unwrap(), Uuid::default());
+    let edge = Edge::new(0, Identifier::new("foo").unwrap(), 0);
     db.delete(
         SpecificEdgeQuery::single(edge)
             .properties()

--- a/lib/src/tests/util.rs
+++ b/lib/src/tests/util.rs
@@ -2,9 +2,7 @@ use crate::errors::{Error, Result};
 use crate::util::{extract_count, extract_edge_properties, extract_edges, extract_vertex_properties, extract_vertices};
 use crate::{models, CountQueryExt, Database, Datastore, QueryExt};
 
-use uuid::Uuid;
-
-pub(crate) fn create_edge_from<D: Datastore>(db: &Database<D>, outbound_id: Uuid) -> Uuid {
+pub(crate) fn create_edge_from<D: Datastore>(db: &Database<D>, outbound_id: u64) -> u64 {
     let inbound_vertex_t = models::Identifier::new("test_inbound_vertex_type").unwrap();
     let inbound_v = models::Vertex::new(inbound_vertex_t);
     db.create_vertex(&inbound_v).unwrap();
@@ -14,11 +12,11 @@ pub(crate) fn create_edge_from<D: Datastore>(db: &Database<D>, outbound_id: Uuid
     inbound_v.id
 }
 
-pub(crate) fn create_edges<D: Datastore>(db: &Database<D>) -> (Uuid, [Uuid; 5]) {
+pub(crate) fn create_edges<D: Datastore>(db: &Database<D>) -> (u64, [u64; 5]) {
     let outbound_vertex_t = models::Identifier::new("test_outbound_vertex_type").unwrap();
     let outbound_v = models::Vertex::new(outbound_vertex_t);
     db.create_vertex(&outbound_v).unwrap();
-    let inbound_ids: [Uuid; 5] = [
+    let inbound_ids: [u64; 5] = [
         create_edge_from(db, outbound_v.id),
         create_edge_from(db, outbound_v.id),
         create_edge_from(db, outbound_v.id),
@@ -46,7 +44,7 @@ pub(crate) fn get_edges<D: Datastore, Q: Into<models::Query>>(db: &Database<D>, 
 
 pub(crate) fn get_edge_count<D: Datastore>(
     db: &Database<D>,
-    id: Uuid,
+    id: u64,
     t: Option<&models::Identifier>,
     direction: models::EdgeDirection,
 ) -> Result<u64> {

--- a/lib/src/tests/util.rs
+++ b/lib/src/tests/util.rs
@@ -4,27 +4,24 @@ use crate::{models, CountQueryExt, Database, Datastore, QueryExt};
 
 pub(crate) fn create_edge_from<D: Datastore>(db: &Database<D>, outbound_id: u64) -> u64 {
     let inbound_vertex_t = models::Identifier::new("test_inbound_vertex_type").unwrap();
-    let inbound_v = models::Vertex::new(inbound_vertex_t);
-    db.create_vertex(&inbound_v).unwrap();
+    let id = db.create_vertex_from_type(inbound_vertex_t).unwrap();
     let edge_t = models::Identifier::new("test_edge_type").unwrap();
-    let edge = models::Edge::new(outbound_id, edge_t, inbound_v.id);
+    let edge = models::Edge::new(outbound_id, edge_t, id);
     db.create_edge(&edge).unwrap();
-    inbound_v.id
+    id
 }
 
 pub(crate) fn create_edges<D: Datastore>(db: &Database<D>) -> (u64, [u64; 5]) {
     let outbound_vertex_t = models::Identifier::new("test_outbound_vertex_type").unwrap();
-    let outbound_v = models::Vertex::new(outbound_vertex_t);
-    db.create_vertex(&outbound_v).unwrap();
+    let id = db.create_vertex_from_type(outbound_vertex_t).unwrap();
     let inbound_ids: [u64; 5] = [
-        create_edge_from(db, outbound_v.id),
-        create_edge_from(db, outbound_v.id),
-        create_edge_from(db, outbound_v.id),
-        create_edge_from(db, outbound_v.id),
-        create_edge_from(db, outbound_v.id),
+        create_edge_from(db, id),
+        create_edge_from(db, id),
+        create_edge_from(db, id),
+        create_edge_from(db, id),
+        create_edge_from(db, id),
     ];
-
-    (outbound_v.id, inbound_ids)
+    (id, inbound_ids)
 }
 
 pub(crate) fn get_vertices<D: Datastore, Q: Into<models::Query>>(

--- a/lib/src/tests/vertex.rs
+++ b/lib/src/tests/vertex.rs
@@ -7,8 +7,6 @@ use crate::{
     SpecificVertexQuery,
 };
 
-use uuid::Uuid;
-
 pub fn should_create_vertex_from_type<D: Datastore>(db: &Database<D>) {
     let t = models::Identifier::new("test_vertex_type").unwrap();
     db.create_vertex_from_type(t).unwrap();
@@ -34,11 +32,7 @@ pub fn should_get_no_vertices_with_zero_limit<D: Datastore>(db: &Database<D>) {
 
 pub fn should_get_range_vertices_out_of_range<D: Datastore>(db: &Database<D>) {
     create_vertices(db);
-    let range = util::get_vertices(
-        db,
-        RangeVertexQuery::new().start_id(Uuid::parse_str("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").unwrap()),
-    )
-    .unwrap();
+    let range = util::get_vertices(db, RangeVertexQuery::new().start_id(u64::max_value())).unwrap();
     assert_eq!(range.len(), 0);
 }
 
@@ -63,7 +57,7 @@ pub fn should_get_single_vertex_nonexisting<D: Datastore>(db: &Database<D>) {
     let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
     let vertex = models::Vertex::new(vertex_t);
     db.create_vertex(&vertex).unwrap();
-    let range = util::get_vertices(db, SpecificVertexQuery::single(Uuid::default())).unwrap();
+    let range = util::get_vertices(db, SpecificVertexQuery::single(0)).unwrap();
     assert_eq!(range.len(), 0);
 }
 
@@ -72,13 +66,13 @@ pub fn should_get_vertices<D: Datastore>(db: &Database<D>) {
 
     let range = util::get_vertices(
         db,
-        SpecificVertexQuery::new(vec![inserted_ids[0], inserted_ids[1], inserted_ids[2], Uuid::default()]),
+        SpecificVertexQuery::new(vec![inserted_ids[0], inserted_ids[1], inserted_ids[2], 0]),
     )
     .unwrap();
 
     assert!(range.len() == 3);
 
-    let mut covered_ids: HashSet<Uuid> = HashSet::new();
+    let mut covered_ids: HashSet<u64> = HashSet::new();
 
     for vertex in &range {
         if let Ok(index) = inserted_ids.binary_search(&vertex.id) {
@@ -183,7 +177,7 @@ pub fn should_delete_a_valid_inbound_vertex<D: Datastore>(db: &Database<D>) {
 }
 
 pub fn should_not_delete_an_invalid_vertex<D: Datastore>(db: &Database<D>) {
-    db.delete(SpecificVertexQuery::single(Uuid::default())).unwrap();
+    db.delete(SpecificVertexQuery::single(0)).unwrap();
 }
 
 pub fn should_get_a_vertex_count<D: Datastore>(db: &Database<D>) {
@@ -214,9 +208,9 @@ pub fn should_not_pipe_on_vertex_count<D: Datastore>(db: &Database<D>) {
     expect_err!(result, errors::Error::OperationOnQuery);
 }
 
-fn check_has_all_vertices(range: Vec<models::Vertex>, mut inserted_ids: Vec<Uuid>) {
+fn check_has_all_vertices(range: Vec<models::Vertex>, mut inserted_ids: Vec<u64>) {
     assert!(range.len() >= 5);
-    let mut covered_ids: HashSet<Uuid> = HashSet::new();
+    let mut covered_ids: HashSet<u64> = HashSet::new();
     for vertex in &range {
         if let Ok(index) = inserted_ids.binary_search(&vertex.id) {
             assert_eq!(vertex.t, models::Identifier::new("test_vertex_type").unwrap());
@@ -228,7 +222,7 @@ fn check_has_all_vertices(range: Vec<models::Vertex>, mut inserted_ids: Vec<Uuid
     }
 }
 
-fn create_vertices<D: Datastore>(db: &Database<D>) -> Vec<Uuid> {
+fn create_vertices<D: Datastore>(db: &Database<D>) -> Vec<u64> {
     let t = models::Identifier::new("test_vertex_type").unwrap();
 
     let vertices = vec![
@@ -243,7 +237,7 @@ fn create_vertices<D: Datastore>(db: &Database<D>) -> Vec<Uuid> {
         db.create_vertex(vertex).unwrap();
     }
 
-    let mut vertex_ids: Vec<Uuid> = vertices.into_iter().map(|v| v.id).collect();
+    let mut vertex_ids: Vec<u64> = vertices.into_iter().map(|v| v.id).collect();
     vertex_ids.sort();
     vertex_ids
 }

--- a/lib/src/util.rs
+++ b/lib/src/util.rs
@@ -6,25 +6,15 @@ use std::hash::{Hash, Hasher};
 use std::io::{Cursor, Error as IoError, Read, Write};
 use std::{str, u8};
 
-use crate::errors::{ValidationError, ValidationResult};
 use crate::models;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use lazy_static::lazy_static;
-use uuid::v1::{Context, Timestamp};
-use uuid::Uuid;
-
-const NODE_ID: [u8; 6] = [0, 0, 0, 0, 0, 0];
-
-lazy_static! {
-    static ref CONTEXT: Context = Context::new(0);
-}
 
 /// A byte-serializable value, frequently employed in the keys of key/value
 /// store.
 pub enum Component<'a> {
-    /// A UUID.
-    Uuid(Uuid),
+    /// A u64.
+    U64(u64),
     /// A fixed length string.
     FixedLengthString(&'a str),
     /// An identifier.
@@ -38,7 +28,7 @@ impl<'a> Component<'a> {
     /// clippy warning.
     pub fn byte_len(&self) -> usize {
         match *self {
-            Component::Uuid(_) => 16,
+            Component::U64(_) => 8,
             Component::FixedLengthString(s) => s.len(),
             Component::Identifier(t) => t.0.len() + 1,
             Component::Json(_) => 8,
@@ -48,7 +38,7 @@ impl<'a> Component<'a> {
     /// Writes a component into a cursor of bytes.
     pub fn write(&self, cursor: &mut Cursor<Vec<u8>>) -> Result<(), IoError> {
         match *self {
-            Component::Uuid(uuid) => cursor.write_all(uuid.as_bytes()),
+            Component::U64(v) => cursor.write_u64::<BigEndian>(v),
             Component::FixedLengthString(s) => cursor.write_all(s.as_bytes()),
             Component::Identifier(i) => {
                 cursor.write_all(&[i.0.len() as u8])?;
@@ -79,16 +69,6 @@ pub fn build(components: &[Component]) -> Vec<u8> {
     }
 
     cursor.into_inner()
-}
-
-/// Reads a UUID from bytes.
-///
-/// # Arguments
-/// * `cursor`: The bytes to read from.
-pub fn read_uuid<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Uuid {
-    let mut buf: [u8; 16] = [0; 16];
-    cursor.read_exact(&mut buf).unwrap();
-    Uuid::from_slice(&buf).unwrap()
 }
 
 /// Reads an identifier from bytes.
@@ -127,35 +107,6 @@ pub fn read_fixed_length_string<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Strin
 /// * `cursor`: The bytes to read from.
 pub fn read_u64<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> u64 {
     cursor.read_u64::<BigEndian>().unwrap()
-}
-
-/// Generates a UUID v1. This utility method uses a shared context and node ID
-/// to help ensure generated UUIDs are unique.
-pub fn generate_uuid_v1() -> Uuid {
-    Uuid::new_v1(Timestamp::now(&*CONTEXT), &NODE_ID)
-}
-
-/// Gets the next UUID that would occur after the given one.
-///
-/// # Arguments
-/// * `uuid`: The input UUID.
-///
-/// # Errors
-/// Returns a `ValidationError` if the input UUID is the great possible value
-/// (i.e., FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF)
-pub fn next_uuid(uuid: Uuid) -> ValidationResult<Uuid> {
-    let mut bytes = *uuid.as_bytes();
-
-    for i in (0..16).rev() {
-        if bytes[i] < 255 {
-            bytes[i] += 1;
-            return Ok(Uuid::from_slice(&bytes[..]).unwrap());
-        } else {
-            bytes[i] = 0;
-        }
-    }
-
-    Err(ValidationError::CannotIncrementUuid)
 }
 
 /// Extracts vertices from the last query output value, or `None`.
@@ -220,32 +171,8 @@ pub fn extract_edge_properties(mut output: Vec<models::QueryOutputValue>) -> Opt
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        extract_count, extract_edge_properties, extract_edges, extract_vertex_properties, extract_vertices,
-        generate_uuid_v1, next_uuid,
-    };
+    use super::{extract_count, extract_edge_properties, extract_edges, extract_vertex_properties, extract_vertices};
     use core::str::FromStr;
-    use uuid::Uuid;
-
-    #[test]
-    fn should_generate_new_uuid_v1() {
-        let first = generate_uuid_v1();
-        let second = generate_uuid_v1();
-        assert_ne!(first, second);
-    }
-
-    #[test]
-    fn should_generate_next_uuid() {
-        let result = next_uuid(Uuid::from_str("16151dea-a538-4bf1-9559-851e256cf139").unwrap());
-        assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            Uuid::from_str("16151dea-a538-4bf1-9559-851e256cf13a").unwrap()
-        );
-
-        let from_uuid = Uuid::from_str("ffffffff-ffff-ffff-ffff-ffffffffffff").unwrap();
-        assert!(next_uuid(from_uuid).is_err());
-    }
 
     #[test]
     fn should_not_extract_vertices_on_empty() {

--- a/lib/src/util.rs
+++ b/lib/src/util.rs
@@ -172,7 +172,6 @@ pub fn extract_edge_properties(mut output: Vec<models::QueryOutputValue>) -> Opt
 #[cfg(test)]
 mod tests {
     use super::{extract_count, extract_edge_properties, extract_edges, extract_vertex_properties, extract_vertices};
-    use core::str::FromStr;
 
     #[test]
     fn should_not_extract_vertices_on_empty() {

--- a/plugins/host/Cargo.toml
+++ b/plugins/host/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2021"
 [dependencies]
 serde_json = "^1.0.57"
 threadpool = "1.8.1"
-uuid = "^1.1.2"
 
 [build-dependencies]
 rustc_version = "0.4.0"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -24,7 +24,6 @@ test-suite = ["indradb-lib/test-suite", "client", "server"]
 
 [dependencies]
 serde_json = "^1.0.57"
-uuid = "^1.2.2"
 prost = "0.11.3"
 prost-derive = "0.11.2"
 prost-types = "0.11.2"

--- a/proto/indradb.proto
+++ b/proto/indradb.proto
@@ -5,11 +5,6 @@ package indradb;
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/empty.proto";
 
-// A UUID.
-message Uuid {
-    bytes value = 1;
-}
-
 // A string that must be less than 256 characters long, and can only contain
 // letters, numbers, dashes and underscores. This is used for vertex and edge
 // types, as well as property names.
@@ -29,11 +24,11 @@ message Json {
 // directed.
 message Edge {
     // The id of the outbound vertex.
-    Uuid outbound_id = 1;
+    uint64 outbound_id = 1;
     // The type of the edge.
     Identifier t = 2;
     // The id of the inbound vertex.
-    Uuid inbound_id = 3;
+    uint64 inbound_id = 3;
 }
 
 // A vertex.
@@ -42,7 +37,7 @@ message Edge {
 // might be a user, or a movie. All vertices have a unique ID and a type.
 message Vertex {
     // The id of the vertex.
-    Uuid id = 1;
+    uint64 id = 1;
     // The type of the vertex.
     Identifier t = 2;
 }
@@ -94,13 +89,13 @@ message RangeVertexQuery {
     // Filters the type of vertices returned.
     Identifier t = 2;
     // Sets the lowest vertex ID to return.
-    Uuid start_id = 3;
+    uint64 start_id = 3;
 }
 
 // Gets a specific set of vertices.
 message SpecificVertexQuery {
     // The IDs of the vertices to get.
-    repeated Uuid ids = 1;
+    repeated uint64 ids = 1;
 }
 
 // Gets vertices with or without a given property.
@@ -247,7 +242,7 @@ message NamedProperty {
 // Represents a vertex property.
 message VertexProperty {
     // The id of the vertex.
-    Uuid id = 1;
+    uint64 id = 1;
     // The property value.
     Json value = 2;
 }
@@ -289,7 +284,7 @@ message BulkInsertItem {
 // A vertex property to insert.
 message VertexPropertyBulkInsertItem {
     reserved 2;
-    Uuid id = 1;
+    uint64 id = 1;
     Identifier name = 4;
     Json value = 3;
 }
@@ -317,6 +312,10 @@ message CreateResponse {
     bool created = 1;
 }
 
+message CreateVertexFromTypeResponse {
+    uint64 id = 1;
+}
+
 // A request to execute a plugin.
 message ExecutePluginRequest {
     string name = 1;
@@ -341,8 +340,8 @@ service IndraDB {
 
     // Creates a new vertex with just a type specification. As opposed to
     // `CreateVertex`, this is used when you do not want to manually specify
-    // the vertex's UUID. Returns the new vertex's UUID.
-    rpc CreateVertexFromType(Identifier) returns (Uuid);
+    // the vertex's ID. Returns the new vertex's ID.
+    rpc CreateVertexFromType(Identifier) returns (CreateVertexFromTypeResponse);
 
     // Creates a new edge.
     rpc CreateEdge(Edge) returns (CreateResponse);

--- a/proto/src/client.rs
+++ b/proto/src/client.rs
@@ -10,7 +10,6 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt;
 use tonic::transport::{Channel, Endpoint, Error as TonicTransportError};
 use tonic::{Request, Status};
-use uuid::Uuid;
 
 const CHANNEL_CAPACITY: usize = 100;
 
@@ -106,7 +105,7 @@ impl Client {
     }
 
     /// Creates a new vertex. Returns whether the vertex was successfully
-    /// created - if this is false, it's because a vertex with the same UUID
+    /// created - if this is false, it's because a vertex with the same ID
     /// already exists.
     ///
     /// # Arguments
@@ -119,14 +118,14 @@ impl Client {
 
     /// Creates a new vertex with just a type specification. As opposed to
     /// `create_vertex`, this is used when you do not want to manually specify
-    /// the vertex's UUID. Returns the new vertex's UUID.
+    /// the vertex's ID. Returns the new vertex's ID.
     ///
     /// # Arguments
     /// * `t`: The type of the vertex to create.
-    pub async fn create_vertex_from_type(&mut self, t: indradb::Identifier) -> Result<Uuid, ClientError> {
+    pub async fn create_vertex_from_type(&mut self, t: indradb::Identifier) -> Result<u64, ClientError> {
         let t: crate::Identifier = t.into();
         let res = self.0.create_vertex_from_type(t).await?;
-        Ok(res.into_inner().try_into()?)
+        Ok(res.into_inner().id)
     }
 
     /// Creates a new edge. If the edge already exists, this will update it

--- a/proto/src/converters.rs
+++ b/proto/src/converters.rs
@@ -121,10 +121,7 @@ impl TryInto<indradb::Vertex> for crate::Vertex {
     type Error = ConversionError;
 
     fn try_into(self) -> Result<indradb::Vertex, Self::Error> {
-        Ok(indradb::Vertex::with_id(
-            self.id,
-            required_field("t", self.t)?.try_into()?,
-        ))
+        Ok(indradb::Vertex::new(self.id, required_field("t", self.t)?.try_into()?))
     }
 }
 

--- a/proto/src/server.rs
+++ b/proto/src/server.rs
@@ -213,11 +213,11 @@ impl<D: indradb::Datastore + Send + Sync + 'static> crate::indra_db_server::Indr
     async fn create_vertex_from_type(
         &self,
         request: Request<crate::Identifier>,
-    ) -> Result<Response<crate::Uuid>, Status> {
+    ) -> Result<Response<crate::CreateVertexFromTypeResponse>, Status> {
         let db = self.db.clone();
         let t = map_conversion_result(request.into_inner().try_into())?;
         let res = map_jh_indra_result(tokio::task::spawn_blocking(move || db.create_vertex_from_type(t)).await)?;
-        Ok(Response::new(res.into()))
+        Ok(Response::new(crate::CreateVertexFromTypeResponse { id: res }))
     }
 
     async fn create_edge(&self, request: Request<crate::Edge>) -> Result<Response<crate::CreateResponse>, Status> {

--- a/proto/src/tests.rs
+++ b/proto/src/tests.rs
@@ -250,9 +250,10 @@ impl<'a> Transaction<'a> for ClientTransaction {
         map_client_result(self.exec.borrow_mut().block_on(self.client.borrow_mut().sync()))
     }
 
-    fn max_id(&self) -> Result<u64> {
+    fn next_id(&self) -> Result<u64> {
         let vertices: Result<Vec<Vertex>> = self.all_vertices()?.collect();
-        Ok(vertices?.into_iter().map(|v| v.id).max().unwrap_or(0))
+        let max_id = vertices?.into_iter().map(|v| v.id).max().unwrap_or(0);
+        Ok(max_id + 1)
     }
 
     fn create_vertex(&mut self, vertex: &Vertex) -> Result<bool> {

--- a/proto/src/tests.rs
+++ b/proto/src/tests.rs
@@ -250,6 +250,11 @@ impl<'a> Transaction<'a> for ClientTransaction {
         map_client_result(self.exec.borrow_mut().block_on(self.client.borrow_mut().sync()))
     }
 
+    fn max_id(&self) -> Result<u64> {
+        let vertices: Result<Vec<Vertex>> = self.all_vertices()?.collect();
+        Ok(vertices?.into_iter().map(|v| v.id).max().unwrap_or(0))
+    }
+
     fn create_vertex(&mut self, vertex: &Vertex) -> Result<bool> {
         map_client_result(
             self.exec

--- a/server/tests/plugins.rs
+++ b/server/tests/plugins.rs
@@ -78,17 +78,17 @@ pub async fn plugins() {
 
     client
         .bulk_insert(vec![
-            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(indradb::Identifier::new("1").unwrap())),
-            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(indradb::Identifier::new("2").unwrap())),
-            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(indradb::Identifier::new("3").unwrap())),
-            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(indradb::Identifier::new("4").unwrap())),
-            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(indradb::Identifier::new("5").unwrap())),
-            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(indradb::Identifier::new("6").unwrap())),
-            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(indradb::Identifier::new("7").unwrap())),
-            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(indradb::Identifier::new("8").unwrap())),
-            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(indradb::Identifier::new("9").unwrap())),
-            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(indradb::Identifier::new("10").unwrap())),
-            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(indradb::Identifier::new("11").unwrap())),
+            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(1, indradb::Identifier::new("1").unwrap())),
+            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(2, indradb::Identifier::new("2").unwrap())),
+            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(3, indradb::Identifier::new("3").unwrap())),
+            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(4, indradb::Identifier::new("4").unwrap())),
+            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(5, indradb::Identifier::new("5").unwrap())),
+            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(6, indradb::Identifier::new("6").unwrap())),
+            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(7, indradb::Identifier::new("7").unwrap())),
+            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(8, indradb::Identifier::new("8").unwrap())),
+            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(9, indradb::Identifier::new("9").unwrap())),
+            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(10, indradb::Identifier::new("10").unwrap())),
+            indradb::BulkInsertItem::Vertex(indradb::Vertex::new(11, indradb::Identifier::new("11").unwrap())),
         ])
         .await
         .unwrap();


### PR DESCRIPTION
Microbenchmarks:

```
BASE
test memory::bench_bulk_insert    ... bench:  10,454,556 ns/iter (+/- 1,511,415)
test memory::bench_create_edge    ... bench:          79 ns/iter (+/- 1)
test memory::bench_create_vertex  ... bench:         269 ns/iter (+/- 11)
test memory::bench_get_edge_count ... bench:          70 ns/iter (+/- 1)
test memory::bench_get_edges      ... bench:         202 ns/iter (+/- 4)
test memory::bench_get_vertices   ... bench:         154 ns/iter (+/- 2)
test rdb::bench_bulk_insert       ... bench:  74,408,906 ns/iter (+/- 21,531,096)
test rdb::bench_create_edge       ... bench:       7,783 ns/iter (+/- 455)
test rdb::bench_create_vertex     ... bench:       5,008 ns/iter (+/- 385)
test rdb::bench_get_edge_count    ... bench:       1,420 ns/iter (+/- 12)
test rdb::bench_get_edges         ... bench:         787 ns/iter (+/- 376)
test rdb::bench_get_vertices      ... bench:         851 ns/iter (+/- 13)

TEST
test memory::bench_bulk_insert    ... bench:   8,393,147 ns/iter (+/- 212,231)
test memory::bench_create_edge    ... bench:          76 ns/iter (+/- 0)
test memory::bench_create_vertex  ... bench:         189 ns/iter (+/- 9)
test memory::bench_get_edge_count ... bench:          68 ns/iter (+/- 0)
test memory::bench_get_edges      ... bench:         201 ns/iter (+/- 0)
test memory::bench_get_vertices   ... bench:         165 ns/iter (+/- 3)
test rdb::bench_bulk_insert       ... bench:  70,774,391 ns/iter (+/- 16,038,766)
test rdb::bench_create_edge       ... bench:       7,625 ns/iter (+/- 158)
test rdb::bench_create_vertex     ... bench:       5,000 ns/iter (+/- 198)
test rdb::bench_get_edge_count    ... bench:       1,429 ns/iter (+/- 10)
test rdb::bench_get_edges         ... bench:         807 ns/iter (+/- 16)
test rdb::bench_get_vertices      ... bench:         870 ns/iter (+/- 11)
```