### PR TITLE
Re-export rocksdb multithreaded features

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -32,5 +32,5 @@ tempfile = "^3.2.0"
 uuid = { version = "^1.2.2", features = ["v1", "serde"] }
 
 # Rocksdb dependencies
-rocksdb = { version = "0.19.0", optional = true }
+rocksdb = { version = "0.19.0", optional = true, features=["multi-threaded-cf"] }
 bincode = { version = "^1.3.3", optional = true }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,6 +20,7 @@ default = []
 rocksdb-datastore = ["rocksdb", "bincode"]
 test-suite = []
 bench-suite = []
+multi-threaded-rocksdb-datastore = ["rocksdb", "bincode", "rocksdb/multi-threaded-cf"]
 
 [dependencies]
 byteorder = "^1.4.2"
@@ -32,5 +33,5 @@ tempfile = "^3.2.0"
 uuid = { version = "^1.2.2", features = ["v1", "serde"] }
 
 # Rocksdb dependencies
-rocksdb = { version = "0.19.0", optional = true, features=["multi-threaded-cf"] }
+rocksdb = { version = "0.19.0", optional = true }
 bincode = { version = "^1.3.3", optional = true }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 rocksdb-datastore = ["rocksdb", "bincode"]
 test-suite = []
 bench-suite = []
-multi-threaded-rocksdb-datastore = ["rocksdb", "bincode", "rocksdb/multi-threaded-cf"]
+rocksdb-multi-threaded = ["rocksdb/multi-threaded-cf"]
 
 [dependencies]
 byteorder = "^1.4.2"

--- a/lib/src/rdb/datastore.rs
+++ b/lib/src/rdb/datastore.rs
@@ -406,7 +406,7 @@ impl RocksdbDatastore {
         let db = match DB::open_cf(&opts, path, CF_NAMES) {
             Ok(db) => db,
             Err(_) => {
-                let mut db = DB::open(&opts, path)?;
+                let db = DB::open(&opts, path)?;
 
                 for cf_name in &CF_NAMES {
                     db.create_cf(cf_name, &opts)?;
@@ -418,6 +418,8 @@ impl RocksdbDatastore {
 
         let metadata_manager = MetadataManager::new(&db);
         let indexed_properties = metadata_manager.get_indexed_properties()?;
+        drop(metadata_manager);
+        
         Ok(Database::new(RocksdbDatastore {
             db: Arc::new(db),
             indexed_properties: Arc::new(RwLock::new(indexed_properties)),

--- a/lib/src/rdb/datastore.rs
+++ b/lib/src/rdb/datastore.rs
@@ -419,7 +419,7 @@ impl RocksdbDatastore {
         let metadata_manager = MetadataManager::new(&db);
         let indexed_properties = metadata_manager.get_indexed_properties()?;
         drop(metadata_manager);
-        
+
         Ok(Database::new(RocksdbDatastore {
             db: Arc::new(db),
             indexed_properties: Arc::new(RwLock::new(indexed_properties)),

--- a/lib/src/rdb/datastore.rs
+++ b/lib/src/rdb/datastore.rs
@@ -406,7 +406,7 @@ impl RocksdbDatastore {
         let db = match DB::open_cf(&opts, path, CF_NAMES) {
             Ok(db) => db,
             Err(_) => {
-                let db = DB::open(&opts, path)?;
+                let mut db = DB::open(&opts, path)?;
 
                 for cf_name in &CF_NAMES {
                     db.create_cf(cf_name, &opts)?;
@@ -437,7 +437,7 @@ impl RocksdbDatastore {
         let db = match DB::open_cf(&opts, path, CF_NAMES) {
             Ok(db) => db,
             Err(_) => {
-                let db = DB::open(&opts, path)?;
+                let mut db = DB::open(&opts, path)?;
 
                 for cf_name in &CF_NAMES {
                     db.create_cf(cf_name, &opts)?;

--- a/lib/src/rdb/managers.rs
+++ b/lib/src/rdb/managers.rs
@@ -8,7 +8,7 @@ use crate::errors::Result;
 use crate::models;
 use crate::util;
 
-use rocksdb::{ColumnFamilyRef, DB, DBIterator, Direction, IteratorMode, WriteBatch};
+use rocksdb::{ColumnFamilyRef, DBIterator, Direction, IteratorMode, WriteBatch, DB};
 use uuid::Uuid;
 
 pub type OwnedPropertyItem = (Uuid, models::Identifier, models::Json);

--- a/lib/src/rdb/managers.rs
+++ b/lib/src/rdb/managers.rs
@@ -2,15 +2,13 @@ use std::collections::HashSet;
 use std::io::Cursor;
 use std::ops::Deref;
 use std::result::Result as StdResult;
-use std::sync::Arc;
 use std::u8;
 
 use crate::errors::Result;
 use crate::models;
 use crate::util;
 
-use rocksdb::BoundColumnFamily;
-use rocksdb::{DBIterator, Direction, IteratorMode, WriteBatch, DB};
+use rocksdb::{ColumnFamilyRef, DB, DBIterator, Direction, IteratorMode, WriteBatch};
 use uuid::Uuid;
 
 pub type OwnedPropertyItem = (Uuid, models::Identifier, models::Json);
@@ -33,7 +31,7 @@ fn take_with_prefix(
 
 pub(crate) struct VertexManager<'a> {
     db: &'a DB,
-    cf: Arc<BoundColumnFamily<'a>>,
+    cf: ColumnFamilyRef<'a>,
 }
 
 impl<'a> VertexManager<'a> {
@@ -184,7 +182,7 @@ impl<'a> EdgeManager<'a> {
 
 pub(crate) struct EdgeRangeManager<'a> {
     db: &'a DB,
-    cf: Arc<BoundColumnFamily<'a>>,
+    cf: ColumnFamilyRef<'a>,
 }
 
 impl<'a> EdgeRangeManager<'a> {
@@ -296,7 +294,7 @@ impl<'a> EdgeRangeManager<'a> {
 
 pub(crate) struct VertexPropertyManager<'a> {
     db: &'a DB,
-    cf: Arc<BoundColumnFamily<'a>>,
+    cf: ColumnFamilyRef<'a>,
 }
 
 impl<'a> VertexPropertyManager<'a> {
@@ -392,7 +390,7 @@ impl<'a> VertexPropertyManager<'a> {
 
 pub(crate) struct EdgePropertyManager<'a> {
     db: &'a DB,
-    cf: Arc<BoundColumnFamily<'a>>,
+    cf: ColumnFamilyRef<'a>,
 }
 
 impl<'a> EdgePropertyManager<'a> {
@@ -506,7 +504,7 @@ impl<'a> EdgePropertyManager<'a> {
 
 pub(crate) struct VertexPropertyValueManager<'a> {
     db: &'a DB,
-    cf: Arc<BoundColumnFamily<'a>>,
+    cf: ColumnFamilyRef<'a>,
 }
 
 impl<'a> VertexPropertyValueManager<'a> {
@@ -598,7 +596,7 @@ impl<'a> VertexPropertyValueManager<'a> {
 
 pub(crate) struct EdgePropertyValueManager<'a> {
     db: &'a DB,
-    cf: Arc<BoundColumnFamily<'a>>,
+    cf: ColumnFamilyRef<'a>,
 }
 
 impl<'a> EdgePropertyValueManager<'a> {
@@ -694,7 +692,7 @@ impl<'a> EdgePropertyValueManager<'a> {
 
 pub(crate) struct MetadataManager<'a> {
     db: &'a DB,
-    cf: Arc<BoundColumnFamily<'a>>,
+    cf: ColumnFamilyRef<'a>,
 }
 
 impl<'a> MetadataManager<'a> {


### PR DESCRIPTION
Details:
- let RocksDatastore be compatible with both single thread and multi thread rocksdb
- add `RocksdbDatastore::new_db_with_options(path, opts)` to allow lib users use their tuned rocksdb options
- re-export the `rocksdb/multi-threaded-cf` feature, named `rocksdb-multi-threaded`, in cargo.toml