### PR TITLE
add API `const_new_unchecked` to `Identifier`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,15 +334,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,7 +431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -485,8 +465,9 @@ version = "3.0.4"
 dependencies = [
  "bincode",
  "byteorder",
- "internment",
  "lazy_static",
+ "once_cell",
+ "parking_lot",
  "rmp-serde",
  "rocksdb",
  "serde",
@@ -541,16 +522,6 @@ dependencies = [
  "tonic",
  "tonic-build",
  "uuid",
-]
-
-[[package]]
-name = "internment"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a798d7677f07d6f1e77be484ea8626ddb1566194de399f1206306820c406371"
-dependencies = [
- "hashbrown 0.12.3",
- "parking_lot",
 ]
 
 [[package]]
@@ -730,9 +701,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+dependencies = [
+ "parking_lot_core",
+]
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "async-stream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +174,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake3"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "digest",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +270,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +351,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -464,6 +536,7 @@ name = "indradb-lib"
 version = "3.0.4"
 dependencies = [
  "bincode",
+ "blake3",
  "byteorder",
  "lazy_static",
  "once_cell",
@@ -1096,6 +1169,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,6 +1445,12 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,13 +23,14 @@ bench-suite = []
 
 [dependencies]
 byteorder = "^1.4.2"
-internment = "0.7.0"
 serde = { version = "^1.0.57", features = ["derive"] }
 serde_json = "^1.0.57"
 lazy_static = "^1.4.0"
 rmp-serde = "1.1.1"
 tempfile = "^3.2.0"
 uuid = { version = "^1.2.2", features = ["v1", "serde"] }
+once_cell = { version = "1.17", features = [ "parking_lot" ] }
+parking_lot = "0.12"
 
 # Rocksdb dependencies
 rocksdb = { version = "0.19.0", optional = true }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -22,6 +22,7 @@ test-suite = []
 bench-suite = []
 
 [dependencies]
+blake3 = "1.3"
 byteorder = "^1.4.2"
 serde = { version = "^1.0.57", features = ["derive"] }
 serde_json = "^1.0.57"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,11 +18,12 @@ path = "src/lib.rs"
 [features]
 default = []
 rocksdb-datastore = ["rocksdb", "bincode"]
+multi-slot = ["blake3"]
 test-suite = []
 bench-suite = []
 
 [dependencies]
-blake3 = "1.3"
+blake3 = { version = "1.3", optional = true }
 byteorder = "^1.4.2"
 serde = { version = "^1.0.57", features = ["derive"] }
 serde_json = "^1.0.57"

--- a/lib/src/models/identifiers.rs
+++ b/lib/src/models/identifiers.rs
@@ -15,7 +15,10 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[derive(Eq, PartialEq, Copy, Clone, Debug, Hash, Ord, PartialOrd)]
 pub struct Identifier(pub(crate) InternedString);
 
+#[cfg(feature = "multi-slot")]
 const INTERN_CONTAINER_COUNT: usize = 32;
+
+#[cfg(feature = "multi-slot")]
 static INTERNED_STRINGS: Lazy<[Mutex<HashSet<&'static str>>; INTERN_CONTAINER_COUNT]> = Lazy::new(|| {
     let mut sets = Vec::with_capacity(INTERN_CONTAINER_COUNT);
     for _ in 0..INTERN_CONTAINER_COUNT {
@@ -23,6 +26,9 @@ static INTERNED_STRINGS: Lazy<[Mutex<HashSet<&'static str>>; INTERN_CONTAINER_CO
     }
     sets.try_into().unwrap()
 });
+#[cfg(not(feature = "multi-slot"))]
+static INTERNED_STRINGS: Lazy<Mutex<HashSet<&'static str>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+
 // Optimize empty intern construction
 static EMPTY_INTERN: Lazy<InternedString> = Lazy::new(|| InternedString::from(""));
 
@@ -52,11 +58,16 @@ impl<S: Into<String>> From<S> for InternedString {
     fn from(s: S) -> Self {
         let s = s.into();
 
-        let hash = blake3::hash(s.as_bytes());
-        let slot = u64::from_le_bytes(hash.as_bytes()[..8].try_into().unwrap());
-        let slot = slot % (INTERN_CONTAINER_COUNT as u64);
+        #[cfg(feature = "multi-slot")]
+        let mut guard = {
+            let hash = blake3::hash(s.as_bytes());
+            let slot = u64::from_le_bytes(hash.as_bytes()[..8].try_into().unwrap());
+            let slot = slot % (INTERN_CONTAINER_COUNT as u64);
+            INTERNED_STRINGS[slot as usize].lock()
+        };
+        #[cfg(not(feature = "multi-slot"))]
+        let mut guard = INTERNED_STRINGS.lock();
 
-        let mut guard = INTERNED_STRINGS[slot as usize].lock();
         if let Some(&p) = guard.get(s.as_str()) {
             InternedString { pointer: p }
         } else {


### PR DESCRIPTION
## What's this PR do
adds the new function `const_new_unchecked` to the Identifier struct, which enables the creation of an identifier with a constant string without any validation check.

## Motivation
Consider following codes:
```rust
mod identifiers {
    const PERSON: Identifier = unsafe { Identifier::const_new_unchecked("person") };
    const MOVIE: Identifier = unsafe { Identifier::const_new_unchecked("movie") };
}
```

This allows to create constant identifiers for encapsulation and abstraction.

## Changes
1. The addition of a new `MayStatic` enum type, which has two possible variants:
    * `Static`: A variant that holds a string reference to a constant `&'static str`.
    * `Interned`: A variant that holds an `Intern<String>` instance.
2. The modification of the existing `Identifier` struct to use the `MayStatic` enum instead of an `Intern<String>` instance to hold the value.
