### PR TITLE
Allow tests and benchmarks to return errors

### DIFF
--- a/lib/src/benches/benches.rs
+++ b/lib/src/benches/benches.rs
@@ -1,24 +1,24 @@
 use crate::{
-    ijson, AllEdgeQuery, BulkInsertItem, CountQueryExt, Database, Datastore, Edge, Identifier, Query,
+    ijson, AllEdgeQuery, BulkInsertItem, CountQueryExt, Database, Datastore, Edge, Error, Identifier, Query,
     SpecificEdgeQuery, SpecificVertexQuery, Vertex,
 };
 
 use test::Bencher;
 
-pub fn bench_create_vertex<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) {
-    let t = Identifier::new("bench_create_vertex").unwrap();
-
+pub fn bench_create_vertex<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) -> Result<(), Error> {
+    let t = Identifier::new("bench_create_vertex")?;
     b.iter(|| {
         let v = Vertex::new(t);
         db.create_vertex(&v).unwrap();
     });
+    Ok(())
 }
 
-pub fn bench_get_vertices<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) {
+pub fn bench_get_vertices<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) -> Result<(), Error> {
     let id = {
-        let t = Identifier::new("bench_get_vertices").unwrap();
+        let t = Identifier::new("bench_get_vertices")?;
         let v = Vertex::new(t);
-        db.create_vertex(&v).unwrap();
+        db.create_vertex(&v)?;
         v.id
     };
 
@@ -27,16 +27,18 @@ pub fn bench_get_vertices<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) {
     b.iter(|| {
         db.get(q.clone()).unwrap();
     });
+
+    Ok(())
 }
 
-pub fn bench_create_edge<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) {
-    let t = Identifier::new("bench_create_edge").unwrap();
+pub fn bench_create_edge<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) -> Result<(), Error> {
+    let t = Identifier::new("bench_create_edge")?;
 
     let (outbound_id, inbound_id) = {
         let outbound_v = Vertex::new(t);
         let inbound_v = Vertex::new(t);
-        db.create_vertex(&outbound_v).unwrap();
-        db.create_vertex(&inbound_v).unwrap();
+        db.create_vertex(&outbound_v)?;
+        db.create_vertex(&inbound_v)?;
         (outbound_v.id, inbound_v.id)
     };
 
@@ -45,18 +47,20 @@ pub fn bench_create_edge<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) {
     b.iter(|| {
         db.create_edge(&edge).unwrap();
     });
+
+    Ok(())
 }
 
-pub fn bench_get_edges<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) {
-    let t = Identifier::new("bench_get_edges").unwrap();
+pub fn bench_get_edges<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) -> Result<(), Error> {
+    let t = Identifier::new("bench_get_edges")?;
 
     let edge = {
         let outbound_v = Vertex::new(t);
         let inbound_v = Vertex::new(t);
-        db.create_vertex(&outbound_v).unwrap();
-        db.create_vertex(&inbound_v).unwrap();
+        db.create_vertex(&outbound_v)?;
+        db.create_vertex(&inbound_v)?;
         let edge = Edge::new(outbound_v.id, t, inbound_v.id);
-        db.create_edge(&edge).unwrap();
+        db.create_edge(&edge)?;
         edge
     };
 
@@ -65,29 +69,33 @@ pub fn bench_get_edges<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) {
     b.iter(|| {
         db.get(q.clone()).unwrap();
     });
+
+    Ok(())
 }
 
-pub fn bench_get_edge_count<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) {
-    let t = Identifier::new("bench_get_edge_count").unwrap();
+pub fn bench_get_edge_count<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) -> Result<(), Error> {
+    let t = Identifier::new("bench_get_edge_count")?;
 
     let outbound_v = Vertex::new(t);
     let inbound_v = Vertex::new(t);
-    db.create_vertex(&outbound_v).unwrap();
-    db.create_vertex(&inbound_v).unwrap();
+    db.create_vertex(&outbound_v)?;
+    db.create_vertex(&inbound_v)?;
     let edge = Edge::new(outbound_v.id, t, inbound_v.id);
-    db.create_edge(&edge).unwrap();
+    db.create_edge(&edge)?;
 
-    let q: Query = AllEdgeQuery.count().unwrap().into();
+    let q: Query = AllEdgeQuery.count()?.into();
 
     b.iter(|| {
         db.get(q.clone()).unwrap();
     });
+
+    Ok(())
 }
 
 const BULK_INSERT_COUNT: usize = 100;
 
-pub fn bench_bulk_insert<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) {
-    let t = Identifier::new("bench_bulk_insert").unwrap();
+pub fn bench_bulk_insert<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) -> Result<(), Error> {
+    let t = Identifier::new("bench_bulk_insert")?;
 
     let mut vertices = Vec::with_capacity(BULK_INSERT_COUNT);
     for _ in 0..BULK_INSERT_COUNT {
@@ -102,7 +110,7 @@ pub fn bench_bulk_insert<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) {
     }
 
     let mut items = Vec::with_capacity(2 * vertices.len() + 2 * edges.len());
-    let t = Identifier::new("is_benchmark").unwrap();
+    let t = Identifier::new("is_benchmark")?;
     for vertex in vertices.into_iter() {
         items.push(BulkInsertItem::Vertex(vertex.clone()));
         items.push(BulkInsertItem::VertexProperty(vertex.id, t, ijson!(true)));
@@ -115,4 +123,6 @@ pub fn bench_bulk_insert<D: Datastore>(b: &mut Bencher, db: &mut Database<D>) {
     b.iter(|| {
         db.bulk_insert(items.clone()).unwrap();
     });
+
+    Ok(())
 }

--- a/lib/src/benches/macros.rs
+++ b/lib/src/benches/macros.rs
@@ -7,7 +7,7 @@ macro_rules! define_bench {
         #[bench]
         fn $name(b: &mut $crate::benches::Bencher) {
             let mut datastore = $datastore_constructor;
-            $crate::benches::$name(b, &mut datastore);
+            $crate::benches::$name(b, &mut datastore).unwrap();
         }
     };
 }

--- a/lib/src/tests/edge.rs
+++ b/lib/src/tests/edge.rs
@@ -2,15 +2,15 @@ use std::collections::HashSet;
 
 use super::util;
 use crate::{
-    ijson, models, AllEdgeQuery, Database, Datastore, Edge, EdgeDirection, QueryExt, SpecificEdgeQuery,
+    ijson, models, AllEdgeQuery, Database, Datastore, Edge, EdgeDirection, Error, QueryExt, SpecificEdgeQuery,
     SpecificVertexQuery,
 };
 
 use uuid::Uuid;
 
-pub fn should_get_all_edges<D: Datastore>(db: &Database<D>) {
-    let (outbound_id, inbound_ids) = util::create_edges(db);
-    let edges = util::get_edges(db, AllEdgeQuery).unwrap();
+pub fn should_get_all_edges<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let (outbound_id, inbound_ids) = util::create_edges(db)?;
+    let edges = util::get_edges(db, AllEdgeQuery)?;
     assert_eq!(
         edges,
         inbound_ids
@@ -18,171 +18,164 @@ pub fn should_get_all_edges<D: Datastore>(db: &Database<D>) {
             .map(|id| Edge::new(outbound_id, models::Identifier::new("test_edge_type").unwrap(), id))
             .collect::<Vec<Edge>>()
     );
+    Ok(())
 }
 
-pub fn should_get_a_valid_edge<D: Datastore>(db: &Database<D>) {
-    let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
-    let outbound_id = db.create_vertex_from_type(vertex_t).unwrap();
-    let inbound_id = db.create_vertex_from_type(vertex_t).unwrap();
-    let edge_t = models::Identifier::new("test_edge_type").unwrap();
+pub fn should_get_a_valid_edge<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let vertex_t = models::Identifier::new("test_vertex_type")?;
+    let outbound_id = db.create_vertex_from_type(vertex_t)?;
+    let inbound_id = db.create_vertex_from_type(vertex_t)?;
+    let edge_t = models::Identifier::new("test_edge_type")?;
     let edge = models::Edge::new(outbound_id, edge_t, inbound_id);
 
-    db.create_edge(&edge).unwrap();
+    db.create_edge(&edge)?;
 
-    let e = util::get_edges(db, SpecificEdgeQuery::single(edge)).unwrap();
+    let e = util::get_edges(db, SpecificEdgeQuery::single(edge))?;
     assert_eq!(e.len(), 1);
     assert_eq!(e[0].outbound_id, outbound_id);
     assert_eq!(e[0].t, edge_t);
     assert_eq!(e[0].inbound_id, inbound_id);
+    Ok(())
 }
 
-pub fn should_not_get_an_invalid_edge<D: Datastore>(db: &Database<D>) {
-    let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
-    let outbound_id = db.create_vertex_from_type(vertex_t).unwrap();
-    let inbound_id = db.create_vertex_from_type(vertex_t).unwrap();
-    let edge_t = models::Identifier::new("test_edge_type").unwrap();
+pub fn should_not_get_an_invalid_edge<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let vertex_t = models::Identifier::new("test_vertex_type")?;
+    let outbound_id = db.create_vertex_from_type(vertex_t)?;
+    let inbound_id = db.create_vertex_from_type(vertex_t)?;
+    let edge_t = models::Identifier::new("test_edge_type")?;
 
     let e = util::get_edges(
         db,
         SpecificEdgeQuery::single(Edge::new(outbound_id, edge_t, Uuid::default())),
-    )
-    .unwrap();
+    )?;
     assert_eq!(e.len(), 0);
     let e = util::get_edges(
         db,
         SpecificEdgeQuery::single(Edge::new(Uuid::default(), edge_t, inbound_id)),
-    )
-    .unwrap();
+    )?;
     assert_eq!(e.len(), 0);
+    Ok(())
 }
 
-pub fn should_create_a_valid_edge<D: Datastore>(db: &Database<D>) {
-    let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
-    let outbound_id = db.create_vertex_from_type(vertex_t).unwrap();
-    let inbound_id = db.create_vertex_from_type(vertex_t).unwrap();
-    let edge_t = models::Identifier::new("test_edge_type").unwrap();
+pub fn should_create_a_valid_edge<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let vertex_t = models::Identifier::new("test_vertex_type")?;
+    let outbound_id = db.create_vertex_from_type(vertex_t)?;
+    let inbound_id = db.create_vertex_from_type(vertex_t)?;
+    let edge_t = models::Identifier::new("test_edge_type")?;
 
     // Set the edge and check
     let edge = models::Edge::new(outbound_id, edge_t, inbound_id);
-    db.create_edge(&edge).unwrap();
-    let e = util::get_edges(db, SpecificEdgeQuery::single(edge.clone())).unwrap();
+    db.create_edge(&edge)?;
+    let e = util::get_edges(db, SpecificEdgeQuery::single(edge.clone()))?;
     assert_eq!(e.len(), 1);
     assert_eq!(edge, e[0]);
 
     // `create_edge` should support the ability of updating an existing edge
     // - test for that
-    db.create_edge(&edge).unwrap();
+    db.create_edge(&edge)?;
 
     // First check that getting a single edge will still...get a single edge
-    let e = util::get_edges(db, SpecificEdgeQuery::single(edge.clone())).unwrap();
+    let e = util::get_edges(db, SpecificEdgeQuery::single(edge.clone()))?;
     assert_eq!(e.len(), 1);
     assert_eq!(edge, e[0]);
 
     // REGRESSION: Second check that getting an edge range will only fetch a
     // single edge
-    let e = util::get_edges(
-        db,
-        SpecificVertexQuery::single(outbound_id).outbound().unwrap().limit(10),
-    )
-    .unwrap();
+    let e = util::get_edges(db, SpecificVertexQuery::single(outbound_id).outbound()?.limit(10))?;
     assert_eq!(e.len(), 1);
     assert_eq!(edge, e[0]);
+    Ok(())
 }
 
-pub fn should_not_create_an_invalid_edge<D: Datastore>(db: &Database<D>) {
-    let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
+pub fn should_not_create_an_invalid_edge<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let vertex_t = models::Identifier::new("test_vertex_type")?;
     let outbound_v = models::Vertex::new(vertex_t);
-    db.create_vertex(&outbound_v).unwrap();
-    let edge_t = models::Identifier::new("test_edge_type").unwrap();
+    db.create_vertex(&outbound_v)?;
+    let edge_t = models::Identifier::new("test_edge_type")?;
     let edge = models::Edge::new(outbound_v.id, edge_t, Uuid::default());
     let result = db.create_edge(&edge);
-    assert_eq!(result.unwrap(), false);
+    assert_eq!(result?, false);
+    Ok(())
 }
 
-pub fn should_delete_a_valid_edge<D: Datastore>(db: &Database<D>) {
-    let vertex_t = models::Identifier::new("test_edge_type").unwrap();
-    let outbound_id = db.create_vertex_from_type(vertex_t).unwrap();
-    let inbound_id = db.create_vertex_from_type(vertex_t).unwrap();
+pub fn should_delete_a_valid_edge<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let vertex_t = models::Identifier::new("test_edge_type")?;
+    let outbound_id = db.create_vertex_from_type(vertex_t)?;
+    let inbound_id = db.create_vertex_from_type(vertex_t)?;
 
-    let edge_t = models::Identifier::new("test_edge_type").unwrap();
+    let edge_t = models::Identifier::new("test_edge_type")?;
     let edge = models::Edge::new(outbound_id, edge_t, inbound_id);
-    db.create_edge(&edge).unwrap();
+    db.create_edge(&edge)?;
 
     let q = SpecificEdgeQuery::single(edge);
-    db.set_properties(q.clone(), models::Identifier::new("foo").unwrap(), &ijson!(true))
-        .unwrap();
+    db.set_properties(q.clone(), models::Identifier::new("foo")?, &ijson!(true))?;
 
-    db.delete(q.clone()).unwrap();
-    let e = util::get_edges(db, q).unwrap();
+    db.delete(q.clone())?;
+    let e = util::get_edges(db, q)?;
     assert_eq!(e.len(), 0);
+    Ok(())
 }
 
-pub fn should_not_delete_an_invalid_edge<D: Datastore>(db: &Database<D>) {
-    let vertex_t = models::Identifier::new("test_edge_type").unwrap();
+pub fn should_not_delete_an_invalid_edge<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let vertex_t = models::Identifier::new("test_edge_type")?;
     let outbound_v = models::Vertex::new(vertex_t);
-    db.create_vertex(&outbound_v).unwrap();
-    let edge_t = models::Identifier::new("test_edge_type").unwrap();
+    db.create_vertex(&outbound_v)?;
+    let edge_t = models::Identifier::new("test_edge_type")?;
     db.delete(SpecificEdgeQuery::single(Edge::new(
         outbound_v.id,
         edge_t,
         Uuid::default(),
-    )))
-    .unwrap();
+    )))?;
+    Ok(())
 }
 
-pub fn should_get_an_edge_count<D: Datastore>(db: &Database<D>) {
-    let (outbound_id, _) = util::create_edges(db);
-    let t = models::Identifier::new("test_edge_type").unwrap();
-    let count = util::get_edge_count(db, outbound_id, Some(t), EdgeDirection::Outbound).unwrap();
+pub fn should_get_an_edge_count<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let (outbound_id, _) = util::create_edges(db)?;
+    let t = models::Identifier::new("test_edge_type")?;
+    let count = util::get_edge_count(db, outbound_id, Some(t), EdgeDirection::Outbound)?;
     assert_eq!(count, 5);
+    Ok(())
 }
 
-pub fn should_get_an_edge_count_with_no_type<D: Datastore>(db: &Database<D>) {
-    let (outbound_id, _) = util::create_edges(db);
-    let count = util::get_edge_count(db, outbound_id, None, EdgeDirection::Outbound).unwrap();
+pub fn should_get_an_edge_count_with_no_type<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let (outbound_id, _) = util::create_edges(db)?;
+    let count = util::get_edge_count(db, outbound_id, None, EdgeDirection::Outbound)?;
     assert_eq!(count, 5);
+    Ok(())
 }
 
-pub fn should_get_an_edge_count_for_an_invalid_edge<D: Datastore>(db: &Database<D>) {
-    let t = models::Identifier::new("test_edge_type").unwrap();
-    let count = util::get_edge_count(db, Uuid::default(), Some(t), EdgeDirection::Outbound).unwrap();
+pub fn should_get_an_edge_count_for_an_invalid_edge<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let t = models::Identifier::new("test_edge_type")?;
+    let count = util::get_edge_count(db, Uuid::default(), Some(t), EdgeDirection::Outbound)?;
     assert_eq!(count, 0);
+    Ok(())
 }
 
-pub fn should_get_an_inbound_edge_count<D: Datastore>(db: &Database<D>) {
-    let (_, inbound_ids) = util::create_edges(db);
-    let count = util::get_edge_count(db, inbound_ids[0], None, EdgeDirection::Inbound).unwrap();
+pub fn should_get_an_inbound_edge_count<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let (_, inbound_ids) = util::create_edges(db)?;
+    let count = util::get_edge_count(db, inbound_ids[0], None, EdgeDirection::Inbound)?;
     assert_eq!(count, 1);
+    Ok(())
 }
 
-pub fn should_get_edges_with_no_type<D: Datastore>(db: &Database<D>) {
-    let (outbound_id, _) = util::create_edges(db);
-    let range = util::get_edges(
-        db,
-        SpecificVertexQuery::single(outbound_id).outbound().unwrap().limit(10),
-    )
-    .unwrap();
-    check_edge_range(&range, outbound_id, 5);
+pub fn should_get_edges_with_no_type<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let (outbound_id, _) = util::create_edges(db)?;
+    let range = util::get_edges(db, SpecificVertexQuery::single(outbound_id).outbound()?.limit(10))?;
+    check_edge_range(&range, outbound_id, 5)?;
+    Ok(())
 }
 
-pub fn should_get_edge_range<D: Datastore>(db: &Database<D>) {
-    let (outbound_id, _) = util::create_edges(db);
-    let t = models::Identifier::new("test_edge_type").unwrap();
-    let range = util::get_edges(
-        db,
-        SpecificVertexQuery::single(outbound_id)
-            .outbound()
-            .unwrap()
-            .limit(100)
-            .t(t),
-    )
-    .unwrap();
-    check_edge_range(&range, outbound_id, 5);
+pub fn should_get_edge_range<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let (outbound_id, _) = util::create_edges(db)?;
+    let t = models::Identifier::new("test_edge_type")?;
+    let range = util::get_edges(db, SpecificVertexQuery::single(outbound_id).outbound()?.limit(100).t(t))?;
+    check_edge_range(&range, outbound_id, 5)?;
+    Ok(())
 }
 
-pub fn should_get_edges<D: Datastore>(db: &Database<D>) {
-    let (outbound_id, inbound_ids) = util::create_edges(db);
-    let t = models::Identifier::new("test_edge_type").unwrap();
+pub fn should_get_edges<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let (outbound_id, inbound_ids) = util::create_edges(db)?;
+    let t = models::Identifier::new("test_edge_type")?;
     let q = SpecificEdgeQuery::new(vec![
         Edge::new(outbound_id, t, inbound_ids[0]),
         Edge::new(outbound_id, t, inbound_ids[1]),
@@ -190,57 +183,48 @@ pub fn should_get_edges<D: Datastore>(db: &Database<D>) {
         Edge::new(outbound_id, t, inbound_ids[3]),
         Edge::new(outbound_id, t, inbound_ids[4]),
     ]);
-    let range = util::get_edges(db, q).unwrap();
-    check_edge_range(&range, outbound_id, 5);
+    let range = util::get_edges(db, q)?;
+    check_edge_range(&range, outbound_id, 5)?;
+    Ok(())
 }
 
-pub fn should_get_edges_piped<D: Datastore>(db: &Database<D>) {
-    let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
+pub fn should_get_edges_piped<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let vertex_t = models::Identifier::new("test_vertex_type")?;
     let outbound_v = models::Vertex::new(vertex_t);
-    db.create_vertex(&outbound_v).unwrap();
+    db.create_vertex(&outbound_v)?;
 
-    let inbound_id = util::create_edge_from(db, outbound_v.id);
+    let inbound_id = util::create_edge_from(db, outbound_v.id)?;
 
     let query_1 = SpecificVertexQuery::single(outbound_v.id)
-        .outbound()
-        .unwrap()
+        .outbound()?
         .limit(1)
-        .t(models::Identifier::new("test_edge_type").unwrap());
-    let range = util::get_edges(db, query_1.clone()).unwrap();
+        .t(models::Identifier::new("test_edge_type")?);
+    let range = util::get_edges(db, query_1.clone())?;
     assert_eq!(range.len(), 1);
     assert_eq!(
         range[0],
-        models::Edge::new(
-            outbound_v.id,
-            models::Identifier::new("test_edge_type").unwrap(),
-            inbound_id
-        )
+        models::Edge::new(outbound_v.id, models::Identifier::new("test_edge_type")?, inbound_id)
     );
 
     let query_2 = query_1
-        .inbound()
-        .unwrap()
+        .inbound()?
         .limit(1)
-        .inbound()
-        .unwrap()
+        .inbound()?
         .limit(1)
-        .t(models::Identifier::new("test_edge_type").unwrap());
-    let range = util::get_edges(db, query_2).unwrap();
+        .t(models::Identifier::new("test_edge_type")?);
+    let range = util::get_edges(db, query_2)?;
     assert_eq!(range.len(), 1);
     assert_eq!(
         range[0],
-        models::Edge::new(
-            outbound_v.id,
-            models::Identifier::new("test_edge_type").unwrap(),
-            inbound_id
-        )
+        models::Edge::new(outbound_v.id, models::Identifier::new("test_edge_type")?, inbound_id)
     );
+    Ok(())
 }
 
-fn check_edge_range(range: &[models::Edge], expected_outbound_id: Uuid, expected_length: usize) {
+fn check_edge_range(range: &[models::Edge], expected_outbound_id: Uuid, expected_length: usize) -> Result<(), Error> {
     assert_eq!(range.len(), expected_length);
     let mut covered_ids: HashSet<Uuid> = HashSet::new();
-    let t = models::Identifier::new("test_edge_type").unwrap();
+    let t = models::Identifier::new("test_edge_type")?;
 
     for edge in range {
         assert_eq!(edge.outbound_id, expected_outbound_id);
@@ -248,4 +232,6 @@ fn check_edge_range(range: &[models::Edge], expected_outbound_id: Uuid, expected
         assert!(!covered_ids.contains(&edge.inbound_id));
         covered_ids.insert(edge.inbound_id);
     }
+
+    Ok(())
 }

--- a/lib/src/tests/indexing.rs
+++ b/lib/src/tests/indexing.rs
@@ -2,139 +2,147 @@ use super::util;
 use crate::{expect_err, ijson, models, Database, Datastore, Error, QueryExt};
 use uuid::Uuid;
 
-fn setup_vertex_with_indexed_property<D: Datastore>(db: &Database<D>, property_name: models::Identifier) -> Uuid {
-    db.index_property(property_name).unwrap();
-    let id = db
-        .create_vertex_from_type(models::Identifier::new("test_vertex_type").unwrap())
-        .unwrap();
+fn setup_vertex_with_indexed_property<D: Datastore>(
+    db: &Database<D>,
+    property_name: models::Identifier,
+) -> Result<Uuid, Error> {
+    db.index_property(property_name)?;
+    let id = db.create_vertex_from_type(models::Identifier::new("test_vertex_type")?)?;
     let q = models::SpecificVertexQuery::single(id);
-    db.set_properties(q, property_name, &ijson!(true)).unwrap();
-    id
+    db.set_properties(q, property_name, &ijson!(true))?;
+    Ok(id)
 }
 
-fn setup_edge_with_indexed_property<D: Datastore>(db: &Database<D>, property_name: models::Identifier) -> models::Edge {
-    db.index_property(property_name).unwrap();
-    let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
-    let outbound_id = db.create_vertex_from_type(vertex_t).unwrap();
-    let inbound_id = db.create_vertex_from_type(vertex_t).unwrap();
-    let edge_t = models::Identifier::new("test_edge_type").unwrap();
+fn setup_edge_with_indexed_property<D: Datastore>(
+    db: &Database<D>,
+    property_name: models::Identifier,
+) -> Result<models::Edge, Error> {
+    db.index_property(property_name)?;
+    let vertex_t = models::Identifier::new("test_vertex_type")?;
+    let outbound_id = db.create_vertex_from_type(vertex_t)?;
+    let inbound_id = db.create_vertex_from_type(vertex_t)?;
+    let edge_t = models::Identifier::new("test_edge_type")?;
     let edge = models::Edge::new(outbound_id, edge_t, inbound_id);
     let q = models::SpecificEdgeQuery::single(edge.clone());
-    db.create_edge(&edge).unwrap();
-    db.set_properties(q, property_name, &ijson!(true)).unwrap();
-    edge
+    db.create_edge(&edge)?;
+    db.set_properties(q, property_name, &ijson!(true))?;
+    Ok(edge)
 }
 
-pub fn should_not_query_unindexed_vertex_property<D: Datastore>(db: &Database<D>) {
+pub fn should_not_query_unindexed_vertex_property<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
     let result = util::get_vertices(
         db,
-        models::VertexWithPropertyPresenceQuery::new(models::Identifier::new("foo").unwrap()),
+        models::VertexWithPropertyPresenceQuery::new(models::Identifier::new("foo")?),
     );
     expect_err!(result, Error::NotIndexed);
+    Ok(())
 }
 
-pub fn should_not_query_unindexed_edge_property<D: Datastore>(db: &Database<D>) {
+pub fn should_not_query_unindexed_edge_property<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
     let result = util::get_edges(
         db,
-        models::EdgeWithPropertyPresenceQuery::new(models::Identifier::new("foo").unwrap()),
+        models::EdgeWithPropertyPresenceQuery::new(models::Identifier::new("foo")?),
     );
     expect_err!(result, Error::NotIndexed);
+    Ok(())
 }
 
-pub fn should_index_existing_vertex_property<D: Datastore>(db: &Database<D>) {
+pub fn should_index_existing_vertex_property<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
     // Setup
-    let property_name = models::Identifier::new("existing-vertex-property").unwrap();
-    let other_property_name = models::Identifier::new("some-other-property").unwrap();
-    let id = db
-        .create_vertex_from_type(models::Identifier::new("test_vertex_type").unwrap())
-        .unwrap();
+    let property_name = models::Identifier::new("existing-vertex-property")?;
+    let other_property_name = models::Identifier::new("some-other-property")?;
+    let id = db.create_vertex_from_type(models::Identifier::new("test_vertex_type")?)?;
     let q = models::SpecificVertexQuery::single(id);
-    db.set_properties(q.clone(), property_name, &ijson!(true)).unwrap();
+    db.set_properties(q.clone(), property_name, &ijson!(true))?;
 
     // Index property
-    db.index_property(property_name).unwrap();
+    db.index_property(property_name)?;
 
     // Get the vertex
-    let result = util::get_vertices(db, models::VertexWithPropertyPresenceQuery::new(property_name)).unwrap();
+    let result = util::get_vertices(db, models::VertexWithPropertyPresenceQuery::new(property_name))?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].id, id);
 
     // Get the vertex with piped queries
-    let result = util::get_vertices(db, q.clone().with_property(property_name).unwrap()).unwrap();
+    let result = util::get_vertices(db, q.clone().with_property(property_name)?)?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].id, id);
-    let result = util::get_vertices(db, q.clone().without_property(property_name).unwrap()).unwrap();
+    let result = util::get_vertices(db, q.clone().without_property(property_name)?)?;
     assert!(result.is_empty());
 
     // Check against another property
-    let result = util::get_vertices(db, q.clone().without_property(other_property_name).unwrap());
+    let result = util::get_vertices(db, q.clone().without_property(other_property_name)?);
     expect_err!(result, Error::NotIndexed);
-    db.index_property(other_property_name.clone()).unwrap();
-    let result = util::get_vertices(db, q.without_property(other_property_name).unwrap()).unwrap();
+    db.index_property(other_property_name.clone())?;
+    let result = util::get_vertices(db, q.without_property(other_property_name)?)?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].id, id);
+    Ok(())
 }
 
-pub fn should_index_existing_edge_property<D: Datastore>(db: &Database<D>) {
+pub fn should_index_existing_edge_property<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
     // Setup
-    let property_name = models::Identifier::new("existing-edge-property").unwrap();
-    let other_property_name = models::Identifier::new("some-other-property").unwrap();
-    let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
-    let outbound_id = db.create_vertex_from_type(vertex_t).unwrap();
-    let inbound_id = db.create_vertex_from_type(vertex_t).unwrap();
-    let edge_t = models::Identifier::new("test_edge_type").unwrap();
+    let property_name = models::Identifier::new("existing-edge-property")?;
+    let other_property_name = models::Identifier::new("some-other-property")?;
+    let vertex_t = models::Identifier::new("test_vertex_type")?;
+    let outbound_id = db.create_vertex_from_type(vertex_t)?;
+    let inbound_id = db.create_vertex_from_type(vertex_t)?;
+    let edge_t = models::Identifier::new("test_edge_type")?;
     let edge = models::Edge::new(outbound_id, edge_t, inbound_id);
 
     let q = models::SpecificEdgeQuery::single(edge.clone());
-    db.create_edge(&edge).unwrap();
-    db.set_properties(q.clone(), property_name, &ijson!(true)).unwrap();
+    db.create_edge(&edge)?;
+    db.set_properties(q.clone(), property_name, &ijson!(true))?;
 
     // Index property
-    db.index_property(property_name).unwrap();
+    db.index_property(property_name)?;
 
     // Get the edge
-    let result = util::get_edges(db, models::EdgeWithPropertyPresenceQuery::new(property_name)).unwrap();
+    let result = util::get_edges(db, models::EdgeWithPropertyPresenceQuery::new(property_name))?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], edge);
 
     // Get the edge with a piped query
-    let result = util::get_edges(db, q.clone().with_property(property_name).unwrap()).unwrap();
+    let result = util::get_edges(db, q.clone().with_property(property_name)?)?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], edge);
-    let result = util::get_edges(db, q.clone().without_property(property_name).unwrap()).unwrap();
+    let result = util::get_edges(db, q.clone().without_property(property_name)?)?;
     assert!(result.is_empty());
 
     // Check against another property
-    let result = util::get_edges(db, q.clone().without_property(other_property_name).unwrap());
+    let result = util::get_edges(db, q.clone().without_property(other_property_name)?);
     expect_err!(result, Error::NotIndexed);
-    db.index_property(other_property_name).unwrap();
-    let result = util::get_edges(db, q.without_property(other_property_name).unwrap()).unwrap();
+    db.index_property(other_property_name)?;
+    let result = util::get_edges(db, q.without_property(other_property_name)?)?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], edge);
+    Ok(())
 }
 
-pub fn should_delete_indexed_vertex_property<D: Datastore>(db: &Database<D>) {
-    let property_name = models::Identifier::new("deletable-vertex-property").unwrap();
-    let id = setup_vertex_with_indexed_property(db, property_name);
+pub fn should_delete_indexed_vertex_property<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let property_name = models::Identifier::new("deletable-vertex-property")?;
+    let id = setup_vertex_with_indexed_property(db, property_name)?;
     let q = models::SpecificVertexQuery::single(id);
-    db.delete(q.clone()).unwrap();
-    let result = util::get_vertices(db, models::VertexWithPropertyPresenceQuery::new(property_name)).unwrap();
+    db.delete(q.clone())?;
+    let result = util::get_vertices(db, models::VertexWithPropertyPresenceQuery::new(property_name))?;
     assert_eq!(result.len(), 0);
+    Ok(())
 }
 
-pub fn should_delete_indexed_edge_property<D: Datastore>(db: &Database<D>) {
-    let property_name = models::Identifier::new("deletable-edge-property").unwrap();
-    let edge = setup_edge_with_indexed_property(db, property_name);
+pub fn should_delete_indexed_edge_property<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let property_name = models::Identifier::new("deletable-edge-property")?;
+    let edge = setup_edge_with_indexed_property(db, property_name)?;
     let q = models::SpecificEdgeQuery::single(edge);
-    db.delete(q.clone()).unwrap();
-    let result = util::get_edges(db, models::EdgeWithPropertyPresenceQuery::new(property_name)).unwrap();
+    db.delete(q.clone())?;
+    let result = util::get_edges(db, models::EdgeWithPropertyPresenceQuery::new(property_name))?;
     assert_eq!(result.len(), 0);
+    Ok(())
 }
 
-pub fn should_update_indexed_vertex_property<D: Datastore>(db: &Database<D>) {
+pub fn should_update_indexed_vertex_property<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
     let json_true = ijson!(true);
     let json_false = ijson!(false);
-    let property_name = models::Identifier::new("updateable-vertex-property").unwrap();
+    let property_name = models::Identifier::new("updateable-vertex-property")?;
 
     // Ensure errors happen when attempting to query before the property is indexed
     let result = util::get_vertices(
@@ -143,32 +151,22 @@ pub fn should_update_indexed_vertex_property<D: Datastore>(db: &Database<D>) {
     );
     expect_err!(result, Error::NotIndexed);
 
-    let id = setup_vertex_with_indexed_property(db, property_name);
+    let id = setup_vertex_with_indexed_property(db, property_name)?;
     let q = models::SpecificVertexQuery::single(id);
-    db.set_properties(q.clone(), property_name, &json_false).unwrap();
+    db.set_properties(q.clone(), property_name, &json_false)?;
 
     // property foo should not be the old value
     let result = util::get_vertices(
         db,
         models::VertexWithPropertyValueQuery::new(property_name, json_true.clone()),
-    )
-    .unwrap();
+    )?;
+    assert_eq!(result.len(), 0);
+    let result = util::get_vertices(db, q.clone().with_property_equal_to(property_name, json_true.clone())?)?;
     assert_eq!(result.len(), 0);
     let result = util::get_vertices(
         db,
-        q.clone()
-            .with_property_equal_to(property_name, json_true.clone())
-            .unwrap(),
-    )
-    .unwrap();
-    assert_eq!(result.len(), 0);
-    let result = util::get_vertices(
-        db,
-        q.clone()
-            .with_property_not_equal_to(property_name, json_true.clone())
-            .unwrap(),
-    )
-    .unwrap();
+        q.clone().with_property_not_equal_to(property_name, json_true.clone())?,
+    )?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].id, id);
 
@@ -176,31 +174,22 @@ pub fn should_update_indexed_vertex_property<D: Datastore>(db: &Database<D>) {
     let result = util::get_vertices(
         db,
         models::VertexWithPropertyValueQuery::new(property_name, json_false.clone()),
-    )
-    .unwrap();
+    )?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].id, id);
-    let result = util::get_vertices(
-        db,
-        q.clone()
-            .with_property_equal_to(property_name, json_false.clone())
-            .unwrap(),
-    )
-    .unwrap();
+    let result = util::get_vertices(db, q.clone().with_property_equal_to(property_name, json_false.clone())?)?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].id, id);
-    let result = util::get_vertices(
-        db,
-        q.with_property_not_equal_to(property_name, json_false.clone()).unwrap(),
-    )
-    .unwrap();
+    let result = util::get_vertices(db, q.with_property_not_equal_to(property_name, json_false.clone())?)?;
     assert_eq!(result.len(), 0);
+
+    Ok(())
 }
 
-pub fn should_update_indexed_edge_property<D: Datastore>(db: &Database<D>) {
+pub fn should_update_indexed_edge_property<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
     let json_true = ijson!(true);
     let json_false = ijson!(false);
-    let property_name = models::Identifier::new("updateable-edge-property").unwrap();
+    let property_name = models::Identifier::new("updateable-edge-property")?;
 
     let result = util::get_edges(
         db,
@@ -208,30 +197,19 @@ pub fn should_update_indexed_edge_property<D: Datastore>(db: &Database<D>) {
     );
     expect_err!(result, Error::NotIndexed);
 
-    let edge = setup_edge_with_indexed_property(db, property_name);
+    let edge = setup_edge_with_indexed_property(db, property_name)?;
     let q = models::SpecificEdgeQuery::single(edge.clone());
-    db.set_properties(q.clone(), property_name, &json_false).unwrap();
+    db.set_properties(q.clone(), property_name, &json_false)?;
 
     // property foo should not be the old value
     let result = util::get_edges(
         db,
         models::EdgeWithPropertyValueQuery::new(property_name, json_true.clone()),
-    )
-    .unwrap();
+    )?;
     assert_eq!(result.len(), 0);
-    let result = util::get_edges(
-        db,
-        q.clone()
-            .with_property_equal_to(property_name, json_true.clone())
-            .unwrap(),
-    )
-    .unwrap();
+    let result = util::get_edges(db, q.clone().with_property_equal_to(property_name, json_true.clone())?)?;
     assert_eq!(result.len(), 0);
-    let result = util::get_edges(
-        db,
-        q.clone().with_property_not_equal_to(property_name, json_true).unwrap(),
-    )
-    .unwrap();
+    let result = util::get_edges(db, q.clone().with_property_not_equal_to(property_name, json_true)?)?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], edge.clone());
 
@@ -239,46 +217,43 @@ pub fn should_update_indexed_edge_property<D: Datastore>(db: &Database<D>) {
     let result = util::get_edges(
         db,
         models::EdgeWithPropertyValueQuery::new(property_name, json_false.clone()),
-    )
-    .unwrap();
+    )?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], edge);
-    let result = util::get_edges(
-        db,
-        q.clone()
-            .with_property_equal_to(property_name, json_false.clone())
-            .unwrap(),
-    )
-    .unwrap();
+    let result = util::get_edges(db, q.clone().with_property_equal_to(property_name, json_false.clone())?)?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0], edge);
-    let result = util::get_edges(db, q.with_property_not_equal_to(property_name, json_false).unwrap()).unwrap();
+    let result = util::get_edges(db, q.with_property_not_equal_to(property_name, json_false)?)?;
     assert_eq!(result.len(), 0);
+
+    Ok(())
 }
 
-pub fn should_query_indexed_vertex_property_empty<D: Datastore>(db: &Database<D>) {
-    let property_name = models::Identifier::new("queryable-vertex-property").unwrap();
-    db.index_property(property_name).unwrap();
-    let result = util::get_vertices(db, models::VertexWithPropertyPresenceQuery::new(property_name)).unwrap();
+pub fn should_query_indexed_vertex_property_empty<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let property_name = models::Identifier::new("queryable-vertex-property")?;
+    db.index_property(property_name)?;
+    let result = util::get_vertices(db, models::VertexWithPropertyPresenceQuery::new(property_name))?;
     assert_eq!(result.len(), 0);
+    Ok(())
 }
 
-pub fn should_query_indexed_edge_property_empty<D: Datastore>(db: &Database<D>) {
-    let property_name = models::Identifier::new("queryable-edge-property").unwrap();
-    db.index_property(property_name).unwrap();
-    let result = util::get_edges(db, models::EdgeWithPropertyPresenceQuery::new(property_name)).unwrap();
+pub fn should_query_indexed_edge_property_empty<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let property_name = models::Identifier::new("queryable-edge-property")?;
+    db.index_property(property_name)?;
+    let result = util::get_edges(db, models::EdgeWithPropertyPresenceQuery::new(property_name))?;
     assert_eq!(result.len(), 0);
+    Ok(())
 }
 
 /// Tests for a regression found by the fuzzer:
 /// https://github.com/indradb/indradb/issues/278
-pub fn should_get_vertex_with_property_value_empty<D: Datastore>(db: &Database<D>) {
-    let property_name = models::Identifier::new("II").unwrap();
-    db.index_property(property_name).unwrap();
+pub fn should_get_vertex_with_property_value_empty<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let property_name = models::Identifier::new("II")?;
+    db.index_property(property_name)?;
     let results = util::get_vertices(
         db,
         models::VertexWithPropertyValueQuery::new(property_name, ijson!(null)),
-    )
-    .unwrap();
+    )?;
     assert_eq!(results.len(), 0);
+    Ok(())
 }

--- a/lib/src/tests/macros.rs
+++ b/lib/src/tests/macros.rs
@@ -16,7 +16,7 @@ macro_rules! define_test {
         #[test]
         fn $name() {
             let db = $db_constructor;
-            $crate::tests::$name(&db);
+            $crate::tests::$name(&db).unwrap();
         }
     };
 }

--- a/lib/src/tests/properties.rs
+++ b/lib/src/tests/properties.rs
@@ -1,317 +1,249 @@
 use super::util;
 use crate::util::extract_count;
 use crate::{
-    errors, expect_err, ijson, AllVertexQuery, CountQueryExt, Database, Datastore, Edge, Identifier, PipePropertyQuery,
-    PipeWithPropertyPresenceQuery, QueryExt, SpecificEdgeQuery, SpecificVertexQuery,
+    errors, expect_err, ijson, AllVertexQuery, CountQueryExt, Database, Datastore, Edge, Error, Identifier,
+    PipePropertyQuery, PipeWithPropertyPresenceQuery, QueryExt, SpecificEdgeQuery, SpecificVertexQuery,
 };
 use uuid::Uuid;
 
-pub fn should_handle_vertex_properties<D: Datastore>(db: &Database<D>) {
-    let t = Identifier::new("test_vertex_type").unwrap();
-    let id = db.create_vertex_from_type(t).unwrap();
+pub fn should_handle_vertex_properties<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let t = Identifier::new("test_vertex_type")?;
+    let id = db.create_vertex_from_type(t)?;
     let q = SpecificVertexQuery::single(id);
 
     // Check to make sure there's no initial value
-    let result = util::get_vertex_properties(
-        db,
-        q.clone().properties().unwrap().name(Identifier::new("foo").unwrap()),
-    )
-    .unwrap();
+    let result = util::get_vertex_properties(db, q.clone().properties()?.name(Identifier::new("foo")?))?;
     assert_eq!(result.len(), 0);
 
     // Set and get the value as true
-    db.set_properties(q.clone(), Identifier::new("foo").unwrap(), &ijson!(true))
-        .unwrap();
-    let result = util::get_vertex_properties(
-        db,
-        q.clone().properties().unwrap().name(Identifier::new("foo").unwrap()),
-    )
-    .unwrap();
+    db.set_properties(q.clone(), Identifier::new("foo")?, &ijson!(true))?;
+    let result = util::get_vertex_properties(db, q.clone().properties()?.name(Identifier::new("foo")?))?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].id, id);
     assert_eq!(result[0].value, ijson!(true));
 
     // Set and get the value as false
-    db.set_properties(q.clone(), Identifier::new("foo").unwrap(), &ijson!(false))
-        .unwrap();
-    let result = util::get_vertex_properties(
-        db,
-        q.clone().properties().unwrap().name(Identifier::new("foo").unwrap()),
-    )
-    .unwrap();
+    db.set_properties(q.clone(), Identifier::new("foo")?, &ijson!(false))?;
+    let result = util::get_vertex_properties(db, q.clone().properties()?.name(Identifier::new("foo")?))?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].id, id);
     assert_eq!(result[0].value, ijson!(false));
 
     // Delete & check that it's deleted
-    db.delete(q.clone().properties().unwrap().name(Identifier::new("foo").unwrap()))
-        .unwrap();
-    let result =
-        util::get_vertex_properties(db, q.properties().unwrap().name(Identifier::new("foo").unwrap())).unwrap();
+    db.delete(q.clone().properties()?.name(Identifier::new("foo")?))?;
+    let result = util::get_vertex_properties(db, q.properties()?.name(Identifier::new("foo")?))?;
     assert_eq!(result.len(), 0);
+
+    Ok(())
 }
 
-pub fn should_get_all_vertex_properties<D: Datastore>(db: &Database<D>) {
-    let t = Identifier::new("a_vertex").unwrap();
-    let v1 = db.create_vertex_from_type(t).unwrap();
-    let v2 = db.create_vertex_from_type(t).unwrap();
-    let v3 = db.create_vertex_from_type(t).unwrap();
+pub fn should_get_all_vertex_properties<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let t = Identifier::new("a_vertex")?;
+    let v1 = db.create_vertex_from_type(t)?;
+    let v2 = db.create_vertex_from_type(t)?;
+    let v3 = db.create_vertex_from_type(t)?;
     let q1 = SpecificVertexQuery::single(v1);
     let q2 = SpecificVertexQuery::single(v2);
     let q3 = SpecificVertexQuery::single(v3);
 
     // Check to make sure there are no initial properties
-    let all_result = util::get_all_vertex_properties(db, q2.clone()).unwrap();
+    let all_result = util::get_all_vertex_properties(db, q2.clone())?;
     assert_eq!(all_result.len(), 0);
 
     // Set and get some properties for v2
-    db.set_properties(q2.clone(), Identifier::new("a").unwrap(), &ijson!(false))
-        .unwrap();
-    db.set_properties(q2.clone(), Identifier::new("b").unwrap(), &ijson!(true))
-        .unwrap();
+    db.set_properties(q2.clone(), Identifier::new("a")?, &ijson!(false))?;
+    db.set_properties(q2.clone(), Identifier::new("b")?, &ijson!(true))?;
 
-    let result_1 = util::get_all_vertex_properties(db, q1).unwrap();
+    let result_1 = util::get_all_vertex_properties(db, q1)?;
     assert_eq!(result_1.len(), 0);
 
-    let result_2 = util::get_all_vertex_properties(db, q2).unwrap();
+    let result_2 = util::get_all_vertex_properties(db, q2)?;
     assert_eq!(result_2.len(), 1);
     assert_eq!(result_2[0].props.len(), 2);
-    assert_eq!(result_2[0].props[0].name, Identifier::new("a").unwrap());
+    assert_eq!(result_2[0].props[0].name, Identifier::new("a")?);
     assert_eq!(result_2[0].props[0].value, ijson!(false));
-    assert_eq!(result_2[0].props[1].name, Identifier::new("b").unwrap());
+    assert_eq!(result_2[0].props[1].name, Identifier::new("b")?);
     assert_eq!(result_2[0].props[1].value, ijson!(true));
 
-    let result_3 = util::get_all_vertex_properties(db, q3).unwrap();
+    let result_3 = util::get_all_vertex_properties(db, q3)?;
     assert_eq!(result_3.len(), 0);
+
+    Ok(())
 }
 
-pub fn should_not_set_invalid_vertex_properties<D: Datastore>(db: &Database<D>) {
+pub fn should_not_set_invalid_vertex_properties<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
     let q = SpecificVertexQuery::single(Uuid::default());
-    db.set_properties(q.clone(), Identifier::new("foo").unwrap(), &ijson!(null))
-        .unwrap();
-    let result =
-        util::get_vertex_properties(db, q.properties().unwrap().name(Identifier::new("foo").unwrap())).unwrap();
+    db.set_properties(q.clone(), Identifier::new("foo")?, &ijson!(null))?;
+    let result = util::get_vertex_properties(db, q.properties()?.name(Identifier::new("foo")?))?;
     assert_eq!(result.len(), 0);
+    Ok(())
 }
 
-pub fn should_not_delete_invalid_vertex_properties<D: Datastore>(db: &Database<D>) {
+pub fn should_not_delete_invalid_vertex_properties<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
     let q = SpecificVertexQuery::single(Uuid::default())
-        .properties()
-        .unwrap()
-        .name(Identifier::new("foo").unwrap());
-    db.delete(q).unwrap();
+        .properties()?
+        .name(Identifier::new("foo")?);
+    db.delete(q)?;
 
-    let id = db.create_vertex_from_type(Identifier::new("foo").unwrap()).unwrap();
+    let id = db.create_vertex_from_type(Identifier::new("foo")?)?;
 
     let q = SpecificVertexQuery::single(id)
-        .properties()
-        .unwrap()
-        .name(Identifier::new("foo").unwrap());
-    db.delete(q).unwrap();
+        .properties()?
+        .name(Identifier::new("foo")?);
+    db.delete(q)?;
+
+    Ok(())
 }
 
-pub fn should_handle_edge_properties<D: Datastore>(db: &Database<D>) {
-    let vertex_t = Identifier::new("test_vertex_type").unwrap();
-    let outbound_id = db.create_vertex_from_type(vertex_t).unwrap();
-    let inbound_id = db.create_vertex_from_type(vertex_t).unwrap();
-    let edge_t = Identifier::new("test_edge_type").unwrap();
+pub fn should_handle_edge_properties<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let vertex_t = Identifier::new("test_vertex_type")?;
+    let outbound_id = db.create_vertex_from_type(vertex_t)?;
+    let inbound_id = db.create_vertex_from_type(vertex_t)?;
+    let edge_t = Identifier::new("test_edge_type")?;
     let edge = Edge::new(outbound_id, edge_t, inbound_id);
     let q = SpecificEdgeQuery::single(edge.clone());
 
-    db.create_edge(&edge).unwrap();
+    db.create_edge(&edge)?;
 
     // Check to make sure there's no initial value
-    let result = util::get_edge_properties(
-        db,
-        q.clone()
-            .properties()
-            .unwrap()
-            .name(Identifier::new("edge-property").unwrap()),
-    )
-    .unwrap();
+    let result = util::get_edge_properties(db, q.clone().properties()?.name(Identifier::new("edge-property")?))?;
     assert_eq!(result.len(), 0);
 
     // Set and get the value as true
-    db.set_properties(q.clone(), Identifier::new("edge-property").unwrap(), &ijson!(true))
-        .unwrap();
-    let result = util::get_edge_properties(
-        db,
-        q.clone()
-            .properties()
-            .unwrap()
-            .name(Identifier::new("edge-property").unwrap()),
-    )
-    .unwrap();
+    db.set_properties(q.clone(), Identifier::new("edge-property")?, &ijson!(true))?;
+    let result = util::get_edge_properties(db, q.clone().properties()?.name(Identifier::new("edge-property")?))?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].edge, edge);
     assert_eq!(result[0].value, ijson!(true));
 
     // Set and get the value as false
-    db.set_properties(q.clone(), Identifier::new("edge-property").unwrap(), &ijson!(false))
-        .unwrap();
-    let result = util::get_edge_properties(
-        db,
-        q.clone()
-            .properties()
-            .unwrap()
-            .name(Identifier::new("edge-property").unwrap()),
-    )
-    .unwrap();
+    db.set_properties(q.clone(), Identifier::new("edge-property")?, &ijson!(false))?;
+    let result = util::get_edge_properties(db, q.clone().properties()?.name(Identifier::new("edge-property")?))?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].edge, edge);
     assert_eq!(result[0].value, ijson!(false));
 
     // Delete & check that it's deleted
-    db.delete(q.clone()).unwrap();
-    let result = util::get_edge_properties(
-        db,
-        q.properties().unwrap().name(Identifier::new("edge-property").unwrap()),
-    )
-    .unwrap();
+    db.delete(q.clone())?;
+    let result = util::get_edge_properties(db, q.properties()?.name(Identifier::new("edge-property")?))?;
     assert_eq!(result.len(), 0);
+
+    Ok(())
 }
 
-pub fn should_get_all_edge_properties<D: Datastore>(db: &Database<D>) {
-    let vertex_t = Identifier::new("test_vertex_type").unwrap();
-    let outbound_id = db.create_vertex_from_type(vertex_t).unwrap();
-    let inbound_id = db.create_vertex_from_type(vertex_t).unwrap();
-    let edge_t = Identifier::new("test_edge_type").unwrap();
+pub fn should_get_all_edge_properties<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let vertex_t = Identifier::new("test_vertex_type")?;
+    let outbound_id = db.create_vertex_from_type(vertex_t)?;
+    let inbound_id = db.create_vertex_from_type(vertex_t)?;
+    let edge_t = Identifier::new("test_edge_type")?;
     let edge = Edge::new(outbound_id, edge_t, inbound_id);
     let eq = SpecificEdgeQuery::single(edge.clone());
 
-    db.create_edge(&edge).unwrap();
+    db.create_edge(&edge)?;
 
     // Check to make sure there's no initial value
-    let result = util::get_all_edge_properties(db, eq.clone()).unwrap();
+    let result = util::get_all_edge_properties(db, eq.clone())?;
     assert_eq!(result.len(), 0);
 
     // Set and get the value as true
-    db.set_properties(eq.clone(), Identifier::new("edge-prop-1").unwrap(), &ijson!(false))
-        .unwrap();
-    db.set_properties(eq.clone(), Identifier::new("edge-prop-2").unwrap(), &ijson!(true))
-        .unwrap();
+    db.set_properties(eq.clone(), Identifier::new("edge-prop-1")?, &ijson!(false))?;
+    db.set_properties(eq.clone(), Identifier::new("edge-prop-2")?, &ijson!(true))?;
 
-    let result = util::get_all_edge_properties(db, eq.clone()).unwrap();
+    let result = util::get_all_edge_properties(db, eq.clone())?;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].props.len(), 2);
-    assert_eq!(result[0].props[0].name, Identifier::new("edge-prop-1").unwrap());
+    assert_eq!(result[0].props[0].name, Identifier::new("edge-prop-1")?);
     assert_eq!(result[0].props[0].value, ijson!(false));
-    assert_eq!(result[0].props[1].name, Identifier::new("edge-prop-2").unwrap());
+    assert_eq!(result[0].props[1].name, Identifier::new("edge-prop-2")?);
     assert_eq!(result[0].props[1].value, ijson!(true));
 
     // Delete & check that they are deleted
-    db.delete(
-        eq.clone()
-            .properties()
-            .unwrap()
-            .name(Identifier::new("edge-prop-1").unwrap()),
-    )
-    .unwrap();
-    db.delete(
-        eq.clone()
-            .properties()
-            .unwrap()
-            .name(Identifier::new("edge-prop-2").unwrap()),
-    )
-    .unwrap();
+    db.delete(eq.clone().properties()?.name(Identifier::new("edge-prop-1")?))?;
+    db.delete(eq.clone().properties()?.name(Identifier::new("edge-prop-2")?))?;
 
-    let result = util::get_all_edge_properties(db, eq).unwrap();
+    let result = util::get_all_edge_properties(db, eq)?;
     assert_eq!(result.len(), 0);
+
+    Ok(())
 }
 
-pub fn should_not_set_invalid_edge_properties<D: Datastore>(db: &Database<D>) {
-    let edge = Edge::new(Uuid::default(), Identifier::new("foo").unwrap(), Uuid::default());
+pub fn should_not_set_invalid_edge_properties<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let edge = Edge::new(Uuid::default(), Identifier::new("foo")?, Uuid::default());
     let q = SpecificEdgeQuery::single(edge);
-    db.set_properties(q.clone(), Identifier::new("bar").unwrap(), &ijson!(null))
-        .unwrap();
-    let result = util::get_edge_properties(db, q.properties().unwrap().name(Identifier::new("bar").unwrap())).unwrap();
+    db.set_properties(q.clone(), Identifier::new("bar")?, &ijson!(null))?;
+    let result = util::get_edge_properties(db, q.properties()?.name(Identifier::new("bar")?))?;
     assert_eq!(result.len(), 0);
+    Ok(())
 }
 
-pub fn should_not_delete_invalid_edge_properties<D: Datastore>(db: &Database<D>) {
-    let edge = Edge::new(Uuid::default(), Identifier::new("foo").unwrap(), Uuid::default());
+pub fn should_not_delete_invalid_edge_properties<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let edge = Edge::new(Uuid::default(), Identifier::new("foo")?, Uuid::default());
     db.delete(
         SpecificEdgeQuery::single(edge)
-            .properties()
-            .unwrap()
-            .name(Identifier::new("bar").unwrap()),
-    )
-    .unwrap();
+            .properties()?
+            .name(Identifier::new("bar")?),
+    )?;
 
-    let outbound_id = db.create_vertex_from_type(Identifier::new("foo").unwrap()).unwrap();
-    let inbound_id = db.create_vertex_from_type(Identifier::new("foo").unwrap()).unwrap();
+    let outbound_id = db.create_vertex_from_type(Identifier::new("foo")?)?;
+    let inbound_id = db.create_vertex_from_type(Identifier::new("foo")?)?;
 
-    let edge = Edge::new(outbound_id, Identifier::new("baz").unwrap(), inbound_id);
-    db.create_edge(&edge).unwrap();
+    let edge = Edge::new(outbound_id, Identifier::new("baz")?, inbound_id);
+    db.create_edge(&edge)?;
     db.delete(
         SpecificEdgeQuery::single(edge)
-            .properties()
-            .unwrap()
-            .name(Identifier::new("bleh").unwrap()),
-    )
-    .unwrap();
+            .properties()?
+            .name(Identifier::new("bleh")?),
+    )?;
+
+    Ok(())
 }
 
-pub fn should_get_an_edge_properties_count<D: Datastore>(db: &Database<D>) {
-    let vertex_t = Identifier::new("test_vertex_type").unwrap();
-    let id = db.create_vertex_from_type(vertex_t).unwrap();
+pub fn should_get_an_edge_properties_count<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let vertex_t = Identifier::new("test_vertex_type")?;
+    let id = db.create_vertex_from_type(vertex_t)?;
     let q = SpecificVertexQuery::single(id);
-    let count = extract_count(
-        db.get(q.outbound().unwrap().properties().unwrap().count().unwrap())
-            .unwrap(),
-    )
-    .unwrap();
+    let count = extract_count(db.get(q.outbound()?.properties()?.count()?)?).unwrap();
     assert!(count == 0);
+    Ok(())
 }
 
-pub fn should_get_a_vertex_properties_count<D: Datastore>(db: &Database<D>) {
-    let vertex_t = Identifier::new("test_vertex_type").unwrap();
-    let id = db.create_vertex_from_type(vertex_t).unwrap();
+pub fn should_get_a_vertex_properties_count<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let vertex_t = Identifier::new("test_vertex_type")?;
+    let id = db.create_vertex_from_type(vertex_t)?;
     let q = SpecificVertexQuery::single(id);
-    db.set_properties(q.clone(), Identifier::new("foo").unwrap(), &ijson!(true))
-        .unwrap();
-    let count = extract_count(
-        db.get(
-            q.properties()
-                .unwrap()
-                .name(Identifier::new("foo").unwrap())
-                .count()
-                .unwrap(),
-        )
-        .unwrap(),
-    )
-    .unwrap();
+    db.set_properties(q.clone(), Identifier::new("foo")?, &ijson!(true))?;
+    let count = extract_count(db.get(q.properties()?.name(Identifier::new("foo")?).count()?)?).unwrap();
     assert!(count >= 1);
+    Ok(())
 }
 
-pub fn should_not_set_properties_on_count<D: Datastore>(db: &Database<D>) {
-    let result = db.set_properties(
-        AllVertexQuery.count().unwrap(),
-        Identifier::new("foo").unwrap(),
-        &ijson!(true),
-    );
+pub fn should_not_set_properties_on_count<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let result = db.set_properties(AllVertexQuery.count()?, Identifier::new("foo")?, &ijson!(true));
     expect_err!(result, errors::Error::OperationOnQuery);
+    Ok(())
 }
 
-pub fn should_not_pipe_properties_on_vertex_count<D: Datastore>(db: &Database<D>) {
+pub fn should_not_pipe_properties_on_vertex_count<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
     // We have to build the query without it's constructor because the
     // constructor will catch this issue and trigger a `ValidationError`.
     let q = PipePropertyQuery {
-        inner: Box::new(AllVertexQuery.count().unwrap().into()),
+        inner: Box::new(AllVertexQuery.count()?.into()),
         name: None,
     };
     let result = db.get(q);
     expect_err!(result, errors::Error::OperationOnQuery);
+    Ok(())
 }
 
-pub fn should_not_pipe_property_presence_on_vertex_count<D: Datastore>(db: &Database<D>) {
+pub fn should_not_pipe_property_presence_on_vertex_count<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
     // We have to build the query without it's constructor because the
     // constructor will catch this issue and trigger a `ValidationError`.
     let q = PipeWithPropertyPresenceQuery {
-        inner: Box::new(AllVertexQuery.count().unwrap().into()),
-        name: Identifier::new("foo").unwrap(),
+        inner: Box::new(AllVertexQuery.count()?.into()),
+        name: Identifier::new("foo")?,
         exists: true,
     };
     let result = db.get(q);
     expect_err!(result, errors::Error::OperationOnQuery);
+    Ok(())
 }

--- a/lib/src/tests/sync.rs
+++ b/lib/src/tests/sync.rs
@@ -1,6 +1,6 @@
-use crate::{Database, Datastore};
+use crate::{Database, Datastore, Error};
 
-pub fn should_sync<D: Datastore>(db: &Database<D>) {
+pub fn should_sync<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
     // just make sure that it runs fine
-    db.sync().unwrap();
+    db.sync()
 }

--- a/lib/src/tests/util.rs
+++ b/lib/src/tests/util.rs
@@ -4,29 +4,29 @@ use crate::{models, CountQueryExt, Database, Datastore, QueryExt};
 
 use uuid::Uuid;
 
-pub(crate) fn create_edge_from<D: Datastore>(db: &Database<D>, outbound_id: Uuid) -> Uuid {
-    let inbound_vertex_t = models::Identifier::new("test_inbound_vertex_type").unwrap();
+pub(crate) fn create_edge_from<D: Datastore>(db: &Database<D>, outbound_id: Uuid) -> Result<Uuid> {
+    let inbound_vertex_t = models::Identifier::new("test_inbound_vertex_type")?;
     let inbound_v = models::Vertex::new(inbound_vertex_t);
-    db.create_vertex(&inbound_v).unwrap();
-    let edge_t = models::Identifier::new("test_edge_type").unwrap();
+    db.create_vertex(&inbound_v)?;
+    let edge_t = models::Identifier::new("test_edge_type")?;
     let edge = models::Edge::new(outbound_id, edge_t, inbound_v.id);
-    db.create_edge(&edge).unwrap();
-    inbound_v.id
+    db.create_edge(&edge)?;
+    Ok(inbound_v.id)
 }
 
-pub(crate) fn create_edges<D: Datastore>(db: &Database<D>) -> (Uuid, [Uuid; 5]) {
-    let outbound_vertex_t = models::Identifier::new("test_outbound_vertex_type").unwrap();
+pub(crate) fn create_edges<D: Datastore>(db: &Database<D>) -> Result<(Uuid, [Uuid; 5])> {
+    let outbound_vertex_t = models::Identifier::new("test_outbound_vertex_type")?;
     let outbound_v = models::Vertex::new(outbound_vertex_t);
-    db.create_vertex(&outbound_v).unwrap();
+    db.create_vertex(&outbound_v)?;
     let inbound_ids: [Uuid; 5] = [
-        create_edge_from(db, outbound_v.id),
-        create_edge_from(db, outbound_v.id),
-        create_edge_from(db, outbound_v.id),
-        create_edge_from(db, outbound_v.id),
-        create_edge_from(db, outbound_v.id),
+        create_edge_from(db, outbound_v.id)?,
+        create_edge_from(db, outbound_v.id)?,
+        create_edge_from(db, outbound_v.id)?,
+        create_edge_from(db, outbound_v.id)?,
+        create_edge_from(db, outbound_v.id)?,
     ];
 
-    (outbound_v.id, inbound_ids)
+    Ok((outbound_v.id, inbound_ids))
 }
 
 pub(crate) fn get_vertices<D: Datastore, Q: Into<models::Query>>(

--- a/lib/src/tests/vertex.rs
+++ b/lib/src/tests/vertex.rs
@@ -1,78 +1,85 @@
 use std::collections::HashSet;
+use std::error::Error as StdError;
 
 use super::util;
 use crate::util::extract_count;
 use crate::{
-    errors, expect_err, ijson, models, AllVertexQuery, CountQueryExt, Database, Datastore, QueryExt, RangeVertexQuery,
-    SpecificVertexQuery,
+    errors, expect_err, ijson, models, AllVertexQuery, CountQueryExt, Database, Datastore, Error, QueryExt,
+    RangeVertexQuery, SpecificVertexQuery,
 };
 
 use uuid::Uuid;
 
-pub fn should_create_vertex_from_type<D: Datastore>(db: &Database<D>) {
-    let t = models::Identifier::new("test_vertex_type").unwrap();
-    db.create_vertex_from_type(t).unwrap();
+pub fn should_create_vertex_from_type<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let t = models::Identifier::new("test_vertex_type")?;
+    db.create_vertex_from_type(t)?;
+    Ok(())
 }
 
-pub fn should_get_all_vertices<D: Datastore>(db: &Database<D>) {
-    let inserted_ids = create_vertices(db);
-    let range = util::get_vertices(db, AllVertexQuery).unwrap();
+pub fn should_get_all_vertices<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let inserted_ids = create_vertices(db)?;
+    let range = util::get_vertices(db, AllVertexQuery)?;
     check_has_all_vertices(range, inserted_ids);
+    Ok(())
 }
 
-pub fn should_get_range_vertices<D: Datastore>(db: &Database<D>) {
-    let inserted_ids = create_vertices(db);
-    let range = util::get_vertices(db, RangeVertexQuery::new()).unwrap();
+pub fn should_get_range_vertices<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let inserted_ids = create_vertices(db)?;
+    let range = util::get_vertices(db, RangeVertexQuery::new())?;
     check_has_all_vertices(range, inserted_ids);
+    Ok(())
 }
 
-pub fn should_get_no_vertices_with_zero_limit<D: Datastore>(db: &Database<D>) {
-    create_vertices(db);
-    let range = util::get_vertices(db, RangeVertexQuery::new().limit(0)).unwrap();
+pub fn should_get_no_vertices_with_zero_limit<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    create_vertices(db)?;
+    let range = util::get_vertices(db, RangeVertexQuery::new().limit(0))?;
     assert_eq!(range.len(), 0);
+    Ok(())
 }
 
-pub fn should_get_range_vertices_out_of_range<D: Datastore>(db: &Database<D>) {
-    create_vertices(db);
+pub fn should_get_range_vertices_out_of_range<D: Datastore>(db: &Database<D>) -> Result<(), Box<dyn StdError>> {
+    create_vertices(db)?;
     let range = util::get_vertices(
         db,
-        RangeVertexQuery::new().start_id(Uuid::parse_str("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").unwrap()),
-    )
-    .unwrap();
+        RangeVertexQuery::new().start_id(Uuid::parse_str("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")?),
+    )?;
     assert_eq!(range.len(), 0);
+    Ok(())
 }
 
-pub fn should_get_no_vertices_with_type_filter<D: Datastore>(db: &Database<D>) {
-    let type_filter = models::Identifier::new("foo").unwrap();
-    create_vertices(db);
-    let range = util::get_vertices(db, RangeVertexQuery::new().t(type_filter)).unwrap();
+pub fn should_get_no_vertices_with_type_filter<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let type_filter = models::Identifier::new("foo")?;
+    create_vertices(db)?;
+    let range = util::get_vertices(db, RangeVertexQuery::new().t(type_filter))?;
     assert_eq!(range.len(), 0);
+    Ok(())
 }
 
-pub fn should_get_single_vertex<D: Datastore>(db: &Database<D>) {
-    let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
-    let id = db.create_vertex_from_type(vertex_t).unwrap();
-    let range = util::get_vertices(db, SpecificVertexQuery::single(id)).unwrap();
+pub fn should_get_single_vertex<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let vertex_t = models::Identifier::new("test_vertex_type")?;
+    let id = db.create_vertex_from_type(vertex_t)?;
+    let range = util::get_vertices(db, SpecificVertexQuery::single(id))?;
     assert_eq!(range.len(), 1);
     assert_eq!(range[0].id, id);
     assert_eq!(range[0].t.as_str(), "test_vertex_type");
+    Ok(())
 }
 
-pub fn should_get_single_vertex_nonexisting<D: Datastore>(db: &Database<D>) {
-    let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
-    db.create_vertex_from_type(vertex_t).unwrap();
-    let range = util::get_vertices(db, SpecificVertexQuery::single(Uuid::default())).unwrap();
+pub fn should_get_single_vertex_nonexisting<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let vertex_t = models::Identifier::new("test_vertex_type")?;
+    db.create_vertex_from_type(vertex_t)?;
+    let range = util::get_vertices(db, SpecificVertexQuery::single(Uuid::default()))?;
     assert_eq!(range.len(), 0);
+    Ok(())
 }
 
-pub fn should_get_vertices<D: Datastore>(db: &Database<D>) {
-    let mut inserted_ids = create_vertices(db);
+pub fn should_get_vertices<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let mut inserted_ids = create_vertices(db)?;
 
     let range = util::get_vertices(
         db,
         SpecificVertexQuery::new(vec![inserted_ids[0], inserted_ids[1], inserted_ids[2], Uuid::default()]),
-    )
-    .unwrap();
+    )?;
 
     assert!(range.len() == 3);
 
@@ -80,129 +87,124 @@ pub fn should_get_vertices<D: Datastore>(db: &Database<D>) {
 
     for vertex in &range {
         if let Ok(index) = inserted_ids.binary_search(&vertex.id) {
-            assert_eq!(vertex.t, models::Identifier::new("test_vertex_type").unwrap());
+            assert_eq!(vertex.t, models::Identifier::new("test_vertex_type")?);
             inserted_ids.remove(index);
         }
 
         assert!(!covered_ids.contains(&vertex.id));
         covered_ids.insert(vertex.id);
     }
+
+    Ok(())
 }
 
-pub fn should_get_vertices_piped<D: Datastore>(db: &Database<D>) {
-    let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
-    let edge_t = models::Identifier::new("test_edge_type").unwrap();
-    let id = db.create_vertex_from_type(vertex_t).unwrap();
-    let inserted_id = util::create_edge_from(db, id);
+pub fn should_get_vertices_piped<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let vertex_t = models::Identifier::new("test_vertex_type")?;
+    let edge_t = models::Identifier::new("test_edge_type")?;
+    let id = db.create_vertex_from_type(vertex_t)?;
+    let inserted_id = util::create_edge_from(db, id)?;
 
     // This query should get `inserted_id`
     let query_1 = SpecificVertexQuery::single(id)
-        .outbound()
-        .unwrap()
+        .outbound()?
         .limit(1)
         .t(edge_t)
-        .inbound()
-        .unwrap()
+        .inbound()?
         .limit(1);
-    let range = util::get_vertices(db, query_1.clone()).unwrap();
+    let range = util::get_vertices(db, query_1.clone())?;
     assert_eq!(range.len(), 1);
     assert_eq!(range[0].id, inserted_id);
 
     // This query should get `inserted_id`
     let query_2 = SpecificVertexQuery::single(id)
-        .outbound()
-        .unwrap()
+        .outbound()?
         .limit(1)
         .t(edge_t)
-        .inbound()
-        .unwrap()
+        .inbound()?
         .limit(1)
-        .t(models::Identifier::new("test_inbound_vertex_type").unwrap());
-    let range = util::get_vertices(db, query_2).unwrap();
+        .t(models::Identifier::new("test_inbound_vertex_type")?);
+    let range = util::get_vertices(db, query_2)?;
     assert_eq!(range.len(), 1);
     assert_eq!(range[0].id, inserted_id);
 
     // This query should get nothing
     let query_3 = SpecificVertexQuery::single(id)
-        .outbound()
-        .unwrap()
+        .outbound()?
         .limit(1)
         .t(edge_t)
-        .inbound()
-        .unwrap()
+        .inbound()?
         .limit(1)
-        .t(models::Identifier::new("foo").unwrap());
-    let range = util::get_vertices(db, query_3).unwrap();
+        .t(models::Identifier::new("foo")?);
+    let range = util::get_vertices(db, query_3)?;
     assert_eq!(range.len(), 0);
 
     // This query should get `v`
-    let query_4 = query_1
-        .inbound()
-        .unwrap()
-        .limit(1)
-        .t(edge_t)
-        .outbound()
-        .unwrap()
-        .limit(1);
-    let range = util::get_vertices(db, query_4).unwrap();
+    let query_4 = query_1.inbound()?.limit(1).t(edge_t).outbound()?.limit(1);
+    let range = util::get_vertices(db, query_4)?;
     assert_eq!(range.len(), 1);
     assert_eq!(range[0].id, id);
+
+    Ok(())
 }
 
-pub fn should_delete_a_valid_outbound_vertex<D: Datastore>(db: &Database<D>) {
-    let (outbound_id, _) = util::create_edges(db);
+pub fn should_delete_a_valid_outbound_vertex<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let (outbound_id, _) = util::create_edges(db)?;
     let q = SpecificVertexQuery::single(outbound_id);
-    db.set_properties(q.clone(), models::Identifier::new("foo").unwrap(), &ijson!(true))
-        .unwrap();
-    db.delete(q.clone()).unwrap();
-    let v = util::get_vertices(db, q).unwrap();
+    db.set_properties(q.clone(), models::Identifier::new("foo")?, &ijson!(true))?;
+    db.delete(q.clone())?;
+    let v = util::get_vertices(db, q)?;
     assert_eq!(v.len(), 0);
-    let t = models::Identifier::new("test_edge_type").unwrap();
-    let count = util::get_edge_count(db, outbound_id, Some(t), models::EdgeDirection::Outbound).unwrap();
+    let t = models::Identifier::new("test_edge_type")?;
+    let count = util::get_edge_count(db, outbound_id, Some(t), models::EdgeDirection::Outbound)?;
     assert_eq!(count, 0);
+    Ok(())
 }
 
-pub fn should_delete_a_valid_inbound_vertex<D: Datastore>(db: &Database<D>) {
-    let (_, inbound_ids) = util::create_edges(db);
+pub fn should_delete_a_valid_inbound_vertex<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let (_, inbound_ids) = util::create_edges(db)?;
     let inbound_id = inbound_ids[0];
     let q = SpecificVertexQuery::single(inbound_id);
-    db.delete(q.clone()).unwrap();
-    let v = util::get_vertices(db, q).unwrap();
+    db.delete(q.clone())?;
+    let v = util::get_vertices(db, q)?;
     assert_eq!(v.len(), 0);
-    let t = models::Identifier::new("test_edge_type").unwrap();
-    let count = util::get_edge_count(db, inbound_id, Some(t), models::EdgeDirection::Inbound).unwrap();
+    let t = models::Identifier::new("test_edge_type")?;
+    let count = util::get_edge_count(db, inbound_id, Some(t), models::EdgeDirection::Inbound)?;
     assert_eq!(count, 0);
+    Ok(())
 }
 
-pub fn should_not_delete_an_invalid_vertex<D: Datastore>(db: &Database<D>) {
-    db.delete(SpecificVertexQuery::single(Uuid::default())).unwrap();
+pub fn should_not_delete_an_invalid_vertex<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    db.delete(SpecificVertexQuery::single(Uuid::default()))
 }
 
-pub fn should_get_a_vertex_count<D: Datastore>(db: &Database<D>) {
-    let vertex_t = models::Identifier::new("test_vertex_type").unwrap();
-    let id = db.create_vertex_from_type(vertex_t).unwrap();
-    let count = util::get_vertex_count(db).unwrap();
+pub fn should_get_a_vertex_count<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let vertex_t = models::Identifier::new("test_vertex_type")?;
+    let id = db.create_vertex_from_type(vertex_t)?;
+    let count = util::get_vertex_count(db)?;
     assert!(count >= 1);
-    let count = extract_count(db.get(SpecificVertexQuery::single(id).count().unwrap()).unwrap()).unwrap();
+    let count = extract_count(db.get(SpecificVertexQuery::single(id).count()?)?).unwrap();
     assert!(count >= 1);
+    Ok(())
 }
 
-pub fn should_not_delete_on_vertex_count<D: Datastore>(db: &Database<D>) {
-    let result = db.delete(AllVertexQuery.count().unwrap());
+pub fn should_not_delete_on_vertex_count<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
+    let result = db.delete(AllVertexQuery.count()?);
     expect_err!(result, errors::Error::OperationOnQuery);
+    Ok(())
 }
 
-pub fn should_not_pipe_on_vertex_count<D: Datastore>(db: &Database<D>) {
+pub fn should_not_pipe_on_vertex_count<D: Datastore>(db: &Database<D>) -> Result<(), Error> {
     // We have to build the query without it's constructor because the
     // constructor will catch this issue and trigger a `ValidationError`.
     let q = models::PipeQuery {
-        inner: Box::new(AllVertexQuery.count().unwrap().into()),
+        inner: Box::new(AllVertexQuery.count()?.into()),
         direction: models::EdgeDirection::Outbound,
         limit: 1,
         t: None,
     };
     let result = db.get(q);
     expect_err!(result, errors::Error::OperationOnQuery);
+    Ok(())
 }
 
 fn check_has_all_vertices(range: Vec<models::Vertex>, mut inserted_ids: Vec<Uuid>) {
@@ -219,12 +221,12 @@ fn check_has_all_vertices(range: Vec<models::Vertex>, mut inserted_ids: Vec<Uuid
     }
 }
 
-fn create_vertices<D: Datastore>(db: &Database<D>) -> Vec<Uuid> {
-    let t = models::Identifier::new("test_vertex_type").unwrap();
+fn create_vertices<D: Datastore>(db: &Database<D>) -> Result<Vec<Uuid>, Error> {
+    let t = models::Identifier::new("test_vertex_type")?;
     let mut ids = Vec::with_capacity(5);
     for _i in 0..5 {
-        let id = db.create_vertex_from_type(t).unwrap();
+        let id = db.create_vertex_from_type(t)?;
         ids.push(id);
     }
-    ids
+    Ok(ids)
 }


### PR DESCRIPTION
This cleans up some of the plumbing of the errors/benchmarks. Rather than sprinkling unwrap everywhere, there's just one in the macro.