### PR TITLE
lib: Use std's OnceLock instead of once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,6 @@ dependencies = [
  "bincode",
  "byteorder",
  "internment",
- "once_cell",
  "rand",
  "rmp-serde",
  "rocksdb",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -24,7 +24,6 @@ bench-suite = ["rand"]
 [dependencies]
 byteorder = "^1.4.2"
 internment = "0.7.0"
-once_cell = "1.17"
 rmp-serde = "1.1.1"
 serde = { version = "^1.0.57", features = ["derive"] }
 serde_json = "^1.0.57"


### PR DESCRIPTION
While this removes once_cell from dependencies, it is still being used
as an indirect dependency due to "internment" crate.

Note that I had to do the same change as in https://github.com/indradb/indradb/pull/305 to make the project compile.

Resolves #292